### PR TITLE
Updating example link to be a relative path

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This framework is intended to work as a testing framework for Azure deployment features by using [Bicep](https://docs.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview?tabs=bicep).
 
-In order to see how you can work with this framework you can find one sample bicep file in the folder [samples](https://github.com/Azure/benchpress/tree/main/examples)
+In order to see how you can work with this framework you can find one sample bicep file in the folder [samples](/examples)
 that will be deployed by using one PowerShell script.
 
 Process is the following:


### PR DESCRIPTION
This small PR changes the link to the samples on the main README file. Instead of using an absolute path, this uses a relative path to the base folder. 

Note the previous link was initially valid, but was broken as part of a file rename int the bicep examples.

