### PR TITLE
#43 Create bicep helper

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,13 @@
 {
   "name": "Benchpress Dev Environment",
-  "image": "mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim",
+  "image": "mcr.microsoft.com/devcontainers/base:bullseye",
   "features": {
     "ghcr.io/devcontainers/features/azure-cli:1": {},
     "ghcr.io/devcontainers/features/common-utils:1": {},
     "ghcr.io/devcontainers/features/docker-from-docker:1": {},
-    "ghcr.io/devcontainers/features/dotnet:1": {},
+    "ghcr.io/devcontainers/features/dotnet:1": {
+      "version": "6"
+    },
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/powershell:1": {},
     "ghcr.io/eitsupi/devcontainer-features/jq-likes:0": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Benchpress Dev Environment",
-  "image": "mcr.microsoft.com/devcontainers/base:bullseye",
+  "image": "mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim",
   "features": {
     "ghcr.io/devcontainers/features/azure-cli:1": {},
     "ghcr.io/devcontainers/features/common-utils:1": {},

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,25 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "PowerShell Attach to Host Process",
+      "type": "PowerShell",
+      "request": "attach",
+      "runspaceId": 1
+    },
+    {
+      "name": "PowerShell Interactive Session",
+      "type": "PowerShell",
+      "request": "launch",
+      "cwd": "${cwd}"
+    },
+    {
+      "name": "PowerShell Launch Current File",
+      "type": "PowerShell",
+      "request": "launch",
+      "script": "${file}",
+      "cwd": "${cwd}"
+    },
+    {
       // Use IntelliSense to find out which attributes exist for C# debugging
       // Use hover for the description of the existing attributes
       // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md

--- a/BenchPress/Helpers/Azure/BenchPress.Azure.psd1
+++ b/BenchPress/Helpers/Azure/BenchPress.Azure.psd1
@@ -23,7 +23,7 @@
   )
   FunctionsToExport = @(
     "Invoke-AzCli",
-    "Confirm-Valid",
+    "Confirm-BicepFile",
     "Deploy-BicepFeature",
     "Remove-BicepFeature",
     "Get-AKSCluster",

--- a/BenchPress/Helpers/Azure/BenchPress.Azure.psd1
+++ b/BenchPress/Helpers/Azure/BenchPress.Azure.psd1
@@ -23,6 +23,7 @@
   )
   FunctionsToExport = @(
     "Invoke-AzCli",
+    "Confirm-Valid",
     "Deploy-BicepFeature",
     "Remove-BicepFeature",
     "Get-AKSCluster",

--- a/BenchPress/Helpers/Azure/Bicep.psm1
+++ b/BenchPress/Helpers/Azure/Bicep.psm1
@@ -1,9 +1,9 @@
 <#
   .SYNOPSIS
-    Confirm-Valid will confirm that the bicep files provided passes the checks executed by `bicep build`.
+    Confirm-BicepFile will confirm that the bicep files provided passes the checks executed by `bicep build`.
 
   .DESCRIPTION
-    Comfirm-Valid executes `bicep build` and returns an object that has an array field BicepErrors. Each element of
+    Confirm-BicepFile executes `bicep build` and returns an object that has an array field BicepErrors. Each element of
     this array is an object that contains the bicep file path that had errors and a collection of
     System.Object.ErrorRecord that correspond to the file at that path:
 
@@ -16,33 +16,33 @@
   .PARAMETER BicepPath
     This is the path to the bicep file that will be confirmed.
     BicepPath is a mandatory parameter.
-    The property name is optional if the path is provided as the first argument to Confirm-Valid.
+    The property name is optional if the path is provided as the first argument to Confirm-BicepFile.
 
   .EXAMPLE
-    ---------- Example 1: Pipe path into Confirm-Valid ----------
+    ---------- Example 1: Pipe path into Confirm-BicepFile ----------
 
-    "./examples/actionGroupErrors.bicep" | Confirm-Valid
+    "./examples/actionGroupErrors.bicep" | Confirm-BicepFile
 
-    Confirm-Valid: ../../../examples/actionGroupErrors.bicep:
-    Confirm-Valid: /workspaces/benchpress/examples/actionGroupErrors.bicep(6,7) : Warning no-unused-params: Parameter "location" is declared but never used. [https://aka.ms/bicep/linter/no-unused-params]
-    Confirm-Valid: /workspaces/benchpress/examples/actionGroupErrors.bicep(12,13) : Warning no-hardcoded-location: A resource location should not use a hard-coded string or variable value. Please use a parameter value, an expression, or the string 'global'. Found: 'westus' [https://aka.ms/bicep/linter/no-hardcoded-location]
+    Confirm-BicepFile: ../../../examples/actionGroupErrors.bicep:
+    Confirm-BicepFile: /workspaces/benchpress/examples/actionGroupErrors.bicep(6,7) : Warning no-unused-params: Parameter "location" is declared but never used. [https://aka.ms/bicep/linter/no-unused-params]
+    Confirm-BicepFile: /workspaces/benchpress/examples/actionGroupErrors.bicep(12,13) : Warning no-hardcoded-location: A resource location should not use a hard-coded string or variable value. Please use a parameter value, an expression, or the string 'global'. Found: 'westus' [https://aka.ms/bicep/linter/no-hardcoded-location]
     0
 
     BicepErrors
     -----------
     {@{Path=../../../examples/actionGroupErrors.bicep; ErrorResults=System.Collections.ObjectModel.Collection`1[System.Management.Automation.PSObject]…
 
-    ---------- Example 2: Pipe multiple paths into Confirm-Valid ----------
+    ---------- Example 2: Pipe multiple paths into Confirm-BicepFile ----------
 
-    "./examples/actionGroupErrors.bicep", "./examples/actionGroupErrors.bicep" | Confirm-Valid
+    "./examples/actionGroupErrors.bicep", "./examples/actionGroupErrors.bicep" | Confirm-BicepFile
 
-    Confirm-Valid: ../../../examples/actionGroupErrors.bicep:
-    Confirm-Valid: /workspaces/benchpress/examples/actionGroupErrors.bicep(6,7) : Warning no-unused-params: Parameter "location" is declared but never used. [https://aka.ms/bicep/linter/no-unused-params]
-    Confirm-Valid: /workspaces/benchpress/examples/actionGroupErrors.bicep(12,13) : Warning no-hardcoded-location: A resource location should not use a hard-coded string or variable value. Please use a parameter value, an expression, or the string 'global'. Found: 'westus' [https://aka.ms/bicep/linter/no-hardcoded-location]
+    Confirm-BicepFile: ../../../examples/actionGroupErrors.bicep:
+    Confirm-BicepFile: /workspaces/benchpress/examples/actionGroupErrors.bicep(6,7) : Warning no-unused-params: Parameter "location" is declared but never used. [https://aka.ms/bicep/linter/no-unused-params]
+    Confirm-BicepFile: /workspaces/benchpress/examples/actionGroupErrors.bicep(12,13) : Warning no-hardcoded-location: A resource location should not use a hard-coded string or variable value. Please use a parameter value, an expression, or the string 'global'. Found: 'westus' [https://aka.ms/bicep/linter/no-hardcoded-location]
     0
-    Confirm-Valid: ../../../examples/actionGroupErrors.bicep:
-    Confirm-Valid: /workspaces/benchpress/examples/actionGroupErrors.bicep(6,7) : Warning no-unused-params: Parameter "location" is declared but never used. [https://aka.ms/bicep/linter/no-unused-params]
-    Confirm-Valid: /workspaces/benchpress/examples/actionGroupErrors.bicep(12,13) : Warning no-hardcoded-location: A resource location should not use a hard-coded string or variable value. Please use a parameter value, an expression, or the string 'global'. Found: 'westus' [https://aka.ms/bicep/linter/no-hardcoded-location]
+    Confirm-BicepFile: ../../../examples/actionGroupErrors.bicep:
+    Confirm-BicepFile: /workspaces/benchpress/examples/actionGroupErrors.bicep(6,7) : Warning no-unused-params: Parameter "location" is declared but never used. [https://aka.ms/bicep/linter/no-unused-params]
+    Confirm-BicepFile: /workspaces/benchpress/examples/actionGroupErrors.bicep(12,13) : Warning no-hardcoded-location: A resource location should not use a hard-coded string or variable value. Please use a parameter value, an expression, or the string 'global'. Found: 'westus' [https://aka.ms/bicep/linter/no-hardcoded-location]
     1
 
     BicepErrors
@@ -51,11 +51,11 @@
 
     ---------- Example 3: Provide -BicepPath Parameter ----------
 
-    Confirm-Valid -BicepPath ./examples/actionGroupErrors.bicep
+    Confirm-BicepFile -BicepPath ./examples/actionGroupErrors.bicep
 
-    Confirm-Valid: ../../../examples/actionGroupErrors.bicep:
-    Confirm-Valid: /workspaces/benchpress/examples/actionGroupErrors.bicep(6,7) : Warning no-unused-params: Parameter "location" is declared but never used. [https://aka.ms/bicep/linter/no-unused-params]
-    Confirm-Valid: /workspaces/benchpress/examples/actionGroupErrors.bicep(12,13) : Warning no-hardcoded-location: A resource location should not use a hard-coded string or variable value. Please use a parameter value, an expression, or the string 'global'. Found: 'westus' [https://aka.ms/bicep/linter/no-hardcoded-location]
+    Confirm-BicepFile: ../../../examples/actionGroupErrors.bicep:
+    Confirm-BicepFile: /workspaces/benchpress/examples/actionGroupErrors.bicep(6,7) : Warning no-unused-params: Parameter "location" is declared but never used. [https://aka.ms/bicep/linter/no-unused-params]
+    Confirm-BicepFile: /workspaces/benchpress/examples/actionGroupErrors.bicep(12,13) : Warning no-hardcoded-location: A resource location should not use a hard-coded string or variable value. Please use a parameter value, an expression, or the string 'global'. Found: 'westus' [https://aka.ms/bicep/linter/no-hardcoded-location]
     0
 
     BicepErrors
@@ -64,11 +64,11 @@
 
     ---------- Example 4: Path without -BicepPath Parameter ----------
 
-    Confirm-Valid ./examples/actionGroupErrors.bicep
+    Confirm-BicepFile ./examples/actionGroupErrors.bicep
 
-    Confirm-Valid: ../../../examples/actionGroupErrors.bicep:
-    Confirm-Valid: /workspaces/benchpress/examples/actionGroupErrors.bicep(6,7) : Warning no-unused-params: Parameter "location" is declared but never used. [https://aka.ms/bicep/linter/no-unused-params]
-    Confirm-Valid: /workspaces/benchpress/examples/actionGroupErrors.bicep(12,13) : Warning no-hardcoded-location: A resource location should not use a hard-coded string or variable value. Please use a parameter value, an expression, or the string 'global'. Found: 'westus' [https://aka.ms/bicep/linter/no-hardcoded-location]
+    Confirm-BicepFile: ../../../examples/actionGroupErrors.bicep:
+    Confirm-BicepFile: /workspaces/benchpress/examples/actionGroupErrors.bicep(6,7) : Warning no-unused-params: Parameter "location" is declared but never used. [https://aka.ms/bicep/linter/no-unused-params]
+    Confirm-BicepFile: /workspaces/benchpress/examples/actionGroupErrors.bicep(12,13) : Warning no-hardcoded-location: A resource location should not use a hard-coded string or variable value. Please use a parameter value, an expression, or the string 'global'. Found: 'westus' [https://aka.ms/bicep/linter/no-hardcoded-location]
     0
 
     BicepErrors

--- a/BenchPress/Helpers/Azure/Bicep.psm1
+++ b/BenchPress/Helpers/Azure/Bicep.psm1
@@ -1,6 +1,6 @@
 <#
   .SYNOPSIS
-    Confirm-BicepFile will confirm that the bicep files provided passes the checks executed by `bicep build`.
+    Confirm-BicepFile will confirm that the bicep files provided pass the checks executed by `bicep build`.
 
   .DESCRIPTION
     Confirm-BicepFile executes `bicep build` and returns an object that has an array field BicepErrors. Each element of

--- a/BenchPress/Helpers/Azure/Bicep.psm1
+++ b/BenchPress/Helpers/Azure/Bicep.psm1
@@ -85,7 +85,7 @@ function Confirm-BicepFile {
   [cmdletbinding()]
   [OutputType([System.Object[]])]
   param(
-    [Parameter(Mandatory, Position=0, ValueFromPipeline)] [string[]]$BicepPath
+    [Parameter(Mandatory, Position=0, ValueFromPipeline)] [string[]]$BicepFilePath
   )
   Begin{
     $out = [PSCustomObject]@{
@@ -93,7 +93,7 @@ function Confirm-BicepFile {
     }
   }
   Process {
-    foreach ($path in $BicepPath) {
+    foreach ($path in $BicepFilePath) {
       # The --stdout parameter will send the built ARM template to stdout instead of creating a file
       # 2>&1 will send errors to stdout so that they can be captured by PowerShell
       # Both the ARM template and any output from linting will be in the array $results, with individual errors in the

--- a/BenchPress/Helpers/Azure/Bicep.psm1
+++ b/BenchPress/Helpers/Azure/Bicep.psm1
@@ -1,3 +1,120 @@
+<#
+  .SYNOPSIS
+    Confirm-Valid will confirm that the bicep files provided passes the checks executed by `bicep build`.
+
+  .DESCRIPTION
+    Comfirm-Valid executes `bicep build` and returns an object that has an array field BicepErrors. Each element of
+    this array is an object that contains the bicep file path that had errors and a collection of
+    System.Object.ErrorRecord that correspond to the file at that path:
+
+    {BicepErrors: [
+        {Path: [string], ErrorResults: [ErrorRecord[]]}, {Path: [string], ErrorResults: [ErrorRecord[]]}, ...
+      ]}
+
+    Any errors will also be output to stdout for capture by CI/CD pipelines.
+
+  .PARAMETER BicepPath
+    This is the path to the bicep file that will be confirmed.
+    BicepPath is a mandatory parameter.
+    The property name is optional if the path is provided as the first argument to Confirm-Valid.
+
+  .EXAMPLE
+    ---------- Example 1: Pipe path into Confirm-Valid ----------
+
+    "./examples/actionGroupErrors.bicep" | Confirm-Valid
+
+    Confirm-Valid: ../../../examples/actionGroupErrors.bicep:
+    Confirm-Valid: /workspaces/benchpress/examples/actionGroupErrors.bicep(6,7) : Warning no-unused-params: Parameter "location" is declared but never used. [https://aka.ms/bicep/linter/no-unused-params]
+    Confirm-Valid: /workspaces/benchpress/examples/actionGroupErrors.bicep(12,13) : Warning no-hardcoded-location: A resource location should not use a hard-coded string or variable value. Please use a parameter value, an expression, or the string 'global'. Found: 'westus' [https://aka.ms/bicep/linter/no-hardcoded-location]
+    0
+
+    BicepErrors
+    -----------
+    {@{Path=../../../examples/actionGroupErrors.bicep; ErrorResults=System.Collections.ObjectModel.Collection`1[System.Management.Automation.PSObject]…
+
+    ---------- Example 2: Pipe multiple paths into Confirm-Valid ----------
+
+    "./examples/actionGroupErrors.bicep", "./examples/actionGroupErrors.bicep" | Confirm-Valid
+
+    Confirm-Valid: ../../../examples/actionGroupErrors.bicep:
+    Confirm-Valid: /workspaces/benchpress/examples/actionGroupErrors.bicep(6,7) : Warning no-unused-params: Parameter "location" is declared but never used. [https://aka.ms/bicep/linter/no-unused-params]
+    Confirm-Valid: /workspaces/benchpress/examples/actionGroupErrors.bicep(12,13) : Warning no-hardcoded-location: A resource location should not use a hard-coded string or variable value. Please use a parameter value, an expression, or the string 'global'. Found: 'westus' [https://aka.ms/bicep/linter/no-hardcoded-location]
+    0
+    Confirm-Valid: ../../../examples/actionGroupErrors.bicep:
+    Confirm-Valid: /workspaces/benchpress/examples/actionGroupErrors.bicep(6,7) : Warning no-unused-params: Parameter "location" is declared but never used. [https://aka.ms/bicep/linter/no-unused-params]
+    Confirm-Valid: /workspaces/benchpress/examples/actionGroupErrors.bicep(12,13) : Warning no-hardcoded-location: A resource location should not use a hard-coded string or variable value. Please use a parameter value, an expression, or the string 'global'. Found: 'westus' [https://aka.ms/bicep/linter/no-hardcoded-location]
+    1
+
+    BicepErrors
+    -----------
+    {@{Path=../../../examples/actionGroupErrors.bicep; ErrorResults=System.Collections.ObjectModel.Collection`1[System.Management.Automation.PSObject]…
+
+    ---------- Example 3: Provide -BicepPath Parameter ----------
+
+    Confirm-Valid -BicepPath ./examples/actionGroupErrors.bicep
+
+    Confirm-Valid: ../../../examples/actionGroupErrors.bicep:
+    Confirm-Valid: /workspaces/benchpress/examples/actionGroupErrors.bicep(6,7) : Warning no-unused-params: Parameter "location" is declared but never used. [https://aka.ms/bicep/linter/no-unused-params]
+    Confirm-Valid: /workspaces/benchpress/examples/actionGroupErrors.bicep(12,13) : Warning no-hardcoded-location: A resource location should not use a hard-coded string or variable value. Please use a parameter value, an expression, or the string 'global'. Found: 'westus' [https://aka.ms/bicep/linter/no-hardcoded-location]
+    0
+
+    BicepErrors
+    -----------
+    {@{Path=../../../examples/actionGroupErrors.bicep; ErrorResults=System.Collections.ObjectModel.Collection`1[System.Management.Automation.PSObject]…
+
+    ---------- Example 4: Path without -BicepPath Parameter ----------
+
+    Confirm-Valid ./examples/actionGroupErrors.bicep
+
+    Confirm-Valid: ../../../examples/actionGroupErrors.bicep:
+    Confirm-Valid: /workspaces/benchpress/examples/actionGroupErrors.bicep(6,7) : Warning no-unused-params: Parameter "location" is declared but never used. [https://aka.ms/bicep/linter/no-unused-params]
+    Confirm-Valid: /workspaces/benchpress/examples/actionGroupErrors.bicep(12,13) : Warning no-hardcoded-location: A resource location should not use a hard-coded string or variable value. Please use a parameter value, an expression, or the string 'global'. Found: 'westus' [https://aka.ms/bicep/linter/no-hardcoded-location]
+    0
+
+    BicepErrors
+    -----------
+    {@{Path=../../../examples/actionGroupErrors.bicep; ErrorResults=System.Collections.ObjectModel.Collection`1[System.Management.Automation.PSObject]…
+
+  .INPUTS
+    System.String[]
+
+  .OUTPUTS
+    System.Management.Automation.PSCustomObject[]
+#>
+function Confirm-BicepFile {
+  [cmdletbinding()]
+  [OutputType([System.Object[]])]
+  param(
+    [Parameter(Mandatory, Position=0, ValueFromPipeline)] [string[]]$BicepPath
+  )
+  Begin{
+    $out = [PSCustomObject]@{
+      BicepErrors = New-Object System.Collections.ArrayList
+    }
+  }
+  Process {
+    foreach ($path in $BicepPath) {
+      # The --stdout parameter will send the built ARM template to stdout instead of creating a file
+      # 2>&1 will send errors to stdout so that they can be captured by PowerShell
+      # Both the ARM template and any output from linting will be in the array $results, with individual errors in the
+      # array separately
+      $results = Invoke-Command -ScriptBlock {bicep build $path --stdout 2>&1}
+      # .Where() returns a collection of System.Object.ErrorRecord or null if there are no errors
+      $errorResults = $results.Where({$PSItem.GetType().Name -eq 'ErrorRecord'})
+
+      if ($errorResults.Count -gt 0) {
+        Write-Error "${path}:"
+        $errorResults | Write-Error
+
+        $out.BicepErrors.Add([PSCustomObject]@{Path = $path; ErrorResults = $errorResults})
+      }
+    }
+  }
+  End {
+    return $out
+  }
+}
+
 function Deploy-BicepFeature([string]$path, $params, $resourceGroupName){
   $fileName = [System.IO.Path]::GetFileNameWithoutExtension($path)
   $folder = Split-Path $path
@@ -33,4 +150,4 @@ function Remove-BicepFeature($resourceGroupName){
   Get-AzResourceGroup -Name $resourceGroupName | Remove-AzResourceGroup -Force
 }
 
-Export-ModuleMember -Function Deploy-BicepFeature, Remove-BicepFeature
+Export-ModuleMember -Function Confirm-BicepFile, Deploy-BicepFeature, Remove-BicepFeature

--- a/examples/actionGroupErrors.bicep
+++ b/examples/actionGroupErrors.bicep
@@ -1,0 +1,24 @@
+/*
+  This file will throw two errors during bicep build. One for unused parameter and the other for hard coding the
+  location.
+*/
+param actionGroupName string = 'sample action group'
+param location string = resourceGroup().location
+
+var actionGroupEmail = 'sampleactiongroup@contoso.com'
+
+resource supportTeamActionGroup 'Microsoft.Insights/actionGroups@2021-09-01' = {
+  name: actionGroupName
+  location: 'westus'
+  properties: {
+    enabled: true
+    groupShortName: actionGroupName
+    emailReceivers: [
+      {
+        name: actionGroupName
+        emailAddress: actionGroupEmail
+        useCommonAlertSchema: true
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Updated the devcontainer to use an image that supports .NET 6.0 so that Generators builds.

Added launch configurations for PowerShell debugging (these still aren't quite right). Added a bicep file that has errors that will manifest during `bicep build`. Added the Confirm-BicepFile cmdlet for validating bicep files against `bicep build`. Added Confirm-BicepFile to the PS Module manifest.