### PR TITLE
Bugfix: Working Directory keyword cannot be used with an action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,8 @@ jobs:
         run: |
           Invoke-Pester -OutputFile ps-test-results.xml -OutputFormat NUnitXml
       - name: Archive PowerShell Test Results
-        working-directory: BenchPress
         if: ${{ success() }} || ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:
-          name: PowerShell Test Results
-          path: |
-            ps-test-results.xml
+          name: powershell-test-results
+          path: BenchPress/ps-test-results.xml


### PR DESCRIPTION
- `working-directory` cannot be used when using an action
  - full path for archival is moved to the `with` keyword