### PR TITLE
Scope PowerShell linting suppression to a function scope rather than global

### DIFF
--- a/.github/config/linter/PSScriptAnalyzerSettings.psd1
+++ b/.github/config/linter/PSScriptAnalyzerSettings.psd1
@@ -1,7 +1,5 @@
 @{
   Severity            = @('Error', 'Warning')
   IncludeDefaultRules = $true
-  ExcludeRules        = @('PSProvideCommentHelp',
-                          'PSUseShouldProcessForStateChangingFunctions',
-                          'PSAvoidUsingInvokeExpression')
+  ExcludeRules        = @('PSProvideCommentHelp')
 }

--- a/BenchPress/Helpers/Azure/AzureCli.psm1
+++ b/BenchPress/Helpers/Azure/AzureCli.psm1
@@ -37,6 +37,7 @@
 #>
 function Invoke-AzCli {
   [CmdletBinding()]
+  [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingInvokeExpression", "")]
   param (
     [Parameter(Mandatory=$true)]
     [string]$Command

--- a/BenchPress/Helpers/Azure/Bicep.psm1
+++ b/BenchPress/Helpers/Azure/Bicep.psm1
@@ -146,7 +146,13 @@ function Deploy-BicepFeature([string]$path, $params, $resourceGroupName){
   Remove-Item "$armPath"
 }
 
-function Remove-BicepFeature($resourceGroupName){
+function Remove-BicepFeature(){
+  [CmdletBinding()]
+  [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
+  param (
+    [Parameter(Mandatory=$true)]
+    [string]$ResourceGroupName
+  )
   Get-AzResourceGroup -Name $resourceGroupName | Remove-AzResourceGroup -Force
 }
 

--- a/BenchPress/Helpers/Azure/Bicep.psm1
+++ b/BenchPress/Helpers/Azure/Bicep.psm1
@@ -153,7 +153,7 @@ function Remove-BicepFeature(){
     [Parameter(Mandatory=$true)]
     [string]$ResourceGroupName
   )
-  Get-AzResourceGroup -Name $resourceGroupName | Remove-AzResourceGroup -Force
+  Get-AzResourceGroup -Name $ResourceGroupName | Remove-AzResourceGroup -Force
 }
 
 Export-ModuleMember -Function Confirm-BicepFile, Deploy-BicepFeature, Remove-BicepFeature


### PR DESCRIPTION
As discussed in design session, longterm suppression of PowerShell linting rules will be moved to function level rather than global level
- Global suppression removed from PSScriptAnalyzer configuration
- Suppression added as cmdlet binding to appropriate functoins
- Casing of parameter name addressed as a result of the above bullet