### PR TITLE
Move unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,26 +16,3 @@ jobs:
       - name: Build Benchpress Solution
         working-directory: BenchPress
         run: dotnet build
-
-  run-unit-tests:
-    name: Run PowerShell Unit Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository and submodules
-        uses: actions/checkout@v3
-      - name: Install Pester module
-        shell: pwsh
-        run: |
-          Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module Pester -ErrorAction Stop
-      - name: Run PowerShell Unit Tests
-        shell: pwsh
-        working-directory: BenchPress
-        run: |
-          Invoke-Pester -OutputFile ps-test-results.xml -OutputFormat NUnitXml
-      - name: Archive PowerShell Test Results
-        if: ${{ success() }} || ${{ failure() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: powershell-test-results
-          path: BenchPress/ps-test-results.xml

--- a/.github/workflows/pr-dotnet.yml
+++ b/.github/workflows/pr-dotnet.yml
@@ -30,9 +30,11 @@ jobs:
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v3
+      - name: Initialize Bicep Submodule
+        run: git submodule update --init --recursive
       - name: Run Unit Tests
         working-directory: BenchPress
-        run: dotnet test --no-restore
+        run: dotnet test
       - name: Archive Unit Test Results
         if: ${{ success() }} || ${{ failure() }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/pr-dotnet.yml
+++ b/.github/workflows/pr-dotnet.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Checkout repository and submodules
         uses: actions/checkout@v3
       - name: Run Unit Tests
-        working-directory: BenchPress
         run: dotnet test
       - name: Archive Unit Test Results
         if: ${{ success() }} || ${{ failure() }}

--- a/.github/workflows/pr-dotnet.yml
+++ b/.github/workflows/pr-dotnet.yml
@@ -23,6 +23,13 @@ jobs:
       - name: Lint .NET Solution
         working-directory: BenchPress
         run: dotnet format --exclude ./bicep/ --verify-no-changes
+  
+  run-unit-tests:
+    name: Run .NET Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v3
       - name: Run Unit Tests
         working-directory: BenchPress
         run: dotnet test

--- a/.github/workflows/pr-dotnet.yml
+++ b/.github/workflows/pr-dotnet.yml
@@ -23,3 +23,12 @@ jobs:
       - name: Lint .NET Solution
         working-directory: BenchPress
         run: dotnet format --exclude ./bicep/ --verify-no-changes
+      - name: Run Unit Tests
+        working-directory: BenchPress
+        run: dotnet test
+      - name: Archive Unit Test Results
+        if: ${{ success() }} || ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: dotnet-test-results
+          path: BenchPress/dotnet-test-results.xml

--- a/.github/workflows/pr-dotnet.yml
+++ b/.github/workflows/pr-dotnet.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Run Unit Tests
         working-directory: BenchPress
-        run: dotnet test
+        run: dotnet test --no-restore
       - name: Archive Unit Test Results
         if: ${{ success() }} || ${{ failure() }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/pr-dotnet.yml
+++ b/.github/workflows/pr-dotnet.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Checkout repository and submodules
         uses: actions/checkout@v3
       - name: Run Unit Tests
+        working-directory: BenchPress
         run: dotnet test
       - name: Archive Unit Test Results
         if: ${{ success() }} || ${{ failure() }}

--- a/.github/workflows/pr-dotnet.yml
+++ b/.github/workflows/pr-dotnet.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Lint .NET Solution
         working-directory: BenchPress
         run: dotnet format --exclude ./bicep/ --verify-no-changes
-  
+
   run-unit-tests:
     name: Run .NET Unit Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-powershell.yml
+++ b/.github/workflows/pr-powershell.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           Invoke-ScriptAnalyzer -Path . -Recurse -EnableExit `
             -Settings $env:LINTER_CONFIG_DIR/PSScriptAnalyzerSettings.psd1
-  
+
   run-unit-tests:
     name: Run PowerShell Unit Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-powershell.yml
+++ b/.github/workflows/pr-powershell.yml
@@ -35,10 +35,11 @@ jobs:
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v3
-      - name: Install Pester module
+      - name: Install unit test module dependencies
         shell: pwsh
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
+          Install-Module Az -ErrorAction Stop
           Install-Module Pester -ErrorAction Stop
       - name: Run PowerShell Unit Tests
         shell: pwsh

--- a/.github/workflows/pr-powershell.yml
+++ b/.github/workflows/pr-powershell.yml
@@ -28,3 +28,26 @@ jobs:
         run: |
           Invoke-ScriptAnalyzer -Path . -Recurse -EnableExit `
             -Settings $env:LINTER_CONFIG_DIR/PSScriptAnalyzerSettings.psd1
+  
+  run-unit-tests:
+    name: Run PowerShell Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v3
+      - name: Install Pester module
+        shell: pwsh
+        run: |
+          Set-PSRepository PSGallery -InstallationPolicy Trusted
+          Install-Module Pester -ErrorAction Stop
+      - name: Run PowerShell Unit Tests
+        shell: pwsh
+        working-directory: BenchPress
+        run: |
+          Invoke-Pester -OutputFile ps-test-results.xml -OutputFormat NUnitXml
+      - name: Archive PowerShell Test Results
+        if: ${{ success() }} || ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: powershell-test-results
+          path: BenchPress/ps-test-results.xml


### PR DESCRIPTION
Shifting unit tests per this [issue](https://github.com/Azure/benchpress/issues/112).

I moved everything out of` ci.yml` to `pr.powershell.yml` since there were only PowerShell unit tests in there.
Don't think we need the archive step since it won't go to CD, but kept in there nonetheless. Open to deleting it.