### PR TITLE
#116 Bug: Install Az Module as part of the CI flow for PowerShell Unit Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,11 @@ jobs:
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v3
-      - name: Install Pester module
+      - name: Install unit test module dependencies
         shell: pwsh
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
+          Install-Module Az -ErrorAction Stop
           Install-Module Pester -ErrorAction Stop
       - name: Run PowerShell Unit Tests
         shell: pwsh


### PR DESCRIPTION
Executing Install-Module Az as a dependency of executing unit tests.