### PR TITLE
#132 GH release executes at incorrect event.

### DIFF
--- a/.github/workflows/cd-github-release.yml
+++ b/.github/workflows/cd-github-release.yml
@@ -3,12 +3,12 @@ name: cd-github-release
 
 on: # yamllint disable-line rule:truthy
   push:
-    branches: [main]
     tags:
       - "v[0-9]+.[0-9]+*"
 
 jobs:
   deploy:
+    if: github.event.base_ref == "refs/heads/main"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Fixed the CD Release trigger to correctly only trigger when the version tag has been pushed and the branch it was pushed to is the main branch.

Closes #132 