### PR TITLE
#99 Resolve .NET Linter Issues

### DIFF
--- a/BenchPress/Generators/ResourceTypes/ResourceType.cs
+++ b/BenchPress/Generators/ResourceTypes/ResourceType.cs
@@ -6,14 +6,21 @@ namespace Generators.ResourceTypes;
 #pragma warning disable CS8602
 public abstract class ResourceType
 {
-    public static ResourceType Create(string resourceType)
+    public static ResourceType Create(string resourceTypeString)
     {
-        return AppDomain.CurrentDomain
+        ResourceType? resourceType = AppDomain.CurrentDomain
             .GetAssemblies()
-            .SelectMany(domainAssembly => domainAssembly.GetTypes())
-            .Where(type => typeof(ResourceType).IsAssignableFrom(type) && !type.IsAbstract)
+            .SelectMany(assembly => assembly.GetTypes())
+            .Where(type => !type.IsAbstract && typeof(ResourceType).IsAssignableFrom(type))
             .Select(type => Activator.CreateInstance(type) as ResourceType)
-            .FirstOrDefault(instance => instance.Id == resourceType);
+            .FirstOrDefault(instance => instance is not null && instance.Id == resourceTypeString);
+
+        if (resourceType is null)
+        {
+            throw new UnknownResourceTypeException(resourceTypeString);
+        }
+
+        return resourceType;
     }
 
     public abstract string Id { get; }

--- a/BenchPress/Generators/TestMetadata.cs
+++ b/BenchPress/Generators/TestMetadata.cs
@@ -13,11 +13,6 @@ public class TestMetadata
         ResourceType = ResourceType.Create(resourceType);
         ResourceName = resourceName;
         ExtraProperties = extraProperties;
-
-        if (ResourceType is null)
-        {
-            throw new UnknownResourceTypeException(resourceType);
-        }
     }
 
     public ResourceType ResourceType { get; set; }


### PR DESCRIPTION
Updated the ResourceType.cs file to fix the linting issues.
Minor refactor of TestMetadata.cs to keep the return type consistent for ResourceType.cs.

Closes #99 