### PR TITLE
Confirm-AzBPResource Initial Implementation

### DIFF
--- a/BenchPress/Helpers/BenchPress.Azure/BenchPress.Azure.psd1
+++ b/BenchPress/Helpers/BenchPress.Azure/BenchPress.Azure.psd1
@@ -46,6 +46,7 @@
     "Get-KeyVaultCertificate",
     "Get-KeyVaultCertificateExist",
     "Get-ResourceByType",
+    "Confirm-Resource"
     "Get-Resource",
     "Get-ResourceGroup",
     "Get-ResourceGroupExist",

--- a/BenchPress/Helpers/BenchPress.Azure/Common.Tests.ps1
+++ b/BenchPress/Helpers/BenchPress.Azure/Common.Tests.ps1
@@ -56,8 +56,8 @@ Describe "Get-Resource" {
 Describe "Confirm-Resource" {
   Context "unit tests" -Tag "Unit" {
     BeforeEach {
-      Mock -ModuleName Common New-NotExistError{}
-      Mock -ModuleName Common New-IncorrectValueError{}
+      Mock -ModuleName Common Format-NotExistError{}
+      Mock -ModuleName Common Format-IncorrectValueError{}
     }
 
     It "Calls Get-ResourceByType; returns true when Get-ResourceByType returns non empty object." {
@@ -66,31 +66,31 @@ Describe "Confirm-Resource" {
       $result = Confirm-Resource -ResourceType "ResourceGroup" -ResourceName "mockResourceName"
 
       Should -InvokeVerifiable
-      Should -Invoke -ModuleName Common -CommandName "New-NotExistError" -Times 0
-      Should -Invoke -ModuleName Common -CommandName "New-IncorrectValueError" -Times 0
+      Should -Invoke -ModuleName Common -CommandName "Format-NotExistError" -Times 0
+      Should -Invoke -ModuleName Common -CommandName "Format-IncorrectValueError" -Times 0
       $result.Success | Should -Be $true
     }
 
-    It "Calls Get-ResourceByType and New-NotExistError; returns false when Get-ResourceByType returns empty object." {
+    It "Calls Get-ResourceByType and Format-NotExistError; returns false when Get-ResourceByType returns empty object." {
       Mock -ModuleName Common Get-ResourceByType{ return $null } -Verifiable
 
       $result = Confirm-Resource -ResourceType "ResourceGroup" -ResourceName "mockResourceName"
 
       Should -InvokeVerifiable
-      Should -Invoke -ModuleName Common -CommandName "New-NotExistError" -Times 1
-      Should -Invoke -ModuleName Common -CommandName "New-IncorrectValueError" -Times 0
+      Should -Invoke -ModuleName Common -CommandName "Format-NotExistError" -Times 1
+      Should -Invoke -ModuleName Common -CommandName "Format-IncorrectValueError" -Times 0
       $result.Success | Should -Be $false
     }
 
-    It "Calls Get-ResourceByType and New-IncorrectValueError; returns false when property does not match value." {
+    It "Calls Get-ResourceByType and Format-IncorrectValueError; returns false when property does not match value." {
       Mock -ModuleName Common Get-ResourceByType{ return  @{TestKey = "WrongValue"} } -Verifiable
 
       $result = Confirm-Resource -ResourceType "ResourceGroup" -ResourceName "mockResourceName" `
         -PropertyKey "TestKey" -PropertyValue "RightValue"
 
       Should -InvokeVerifiable
-      Should -Invoke -ModuleName Common -CommandName "New-NotExistError" -Times 0
-      Should -Invoke -ModuleName Common -CommandName "New-IncorrectValueError" -Times 1
+      Should -Invoke -ModuleName Common -CommandName "Format-NotExistError" -Times 0
+      Should -Invoke -ModuleName Common -CommandName "Format-IncorrectValueError" -Times 1
 
       $result.Success | Should -Be $false
     }
@@ -99,21 +99,21 @@ Describe "Confirm-Resource" {
 
 Describe "ErrorRecord Helper Methods" {
   Context "unit tests" -Tag "Unit" {
-    It "Calls New-ErrorRecord when New-NotExistError is called" {
-      Mock -ModuleName Common New-ErrorRecord{} -Verifiable
-      New-NotExistError -Message "testMessage"
+    It "Calls Format-ErrorRecord when Format-NotExistError is called" {
+      Mock -ModuleName Common Format-ErrorRecord{} -Verifiable
+      Format-NotExistError -Message "testMessage"
       Should -InvokeVerifiable
     }
 
-    It "Calls New-ErrorRecord when New-IncorrectValueError is called" {
-      Mock -ModuleName Common New-ErrorRecord{} -Verifiable
-      New-IncorrectValueError -Message "testMessage"
+    It "Calls Format-ErrorRecord when Format-IncorrectValueError is called" {
+      Mock -ModuleName Common Format-ErrorRecord{} -Verifiable
+      Format-IncorrectValueError -Message "testMessage"
       Should -InvokeVerifiable
     }
 
-    It "Creates ErrorRecord with correct message and ID when New-ErrorRecord is called" {
-      Mock -ModuleName Common New-Object{} -Verifiable
-      New-ErrorRecord -Message "testMessage" -ErrorID "testErrorID"
+    It "Creates ErrorRecord with correct message and ID when Format-ErrorRecord is called" {
+      Mock -ModuleName Common Format-Object{} -Verifiable
+      Format-ErrorRecord -Message "testMessage" -ErrorID "testErrorID"
       Should -InvokeVerifiable
     }
   }

--- a/BenchPress/Helpers/BenchPress.Azure/Common.Tests.ps1
+++ b/BenchPress/Helpers/BenchPress.Azure/Common.Tests.ps1
@@ -112,7 +112,7 @@ Describe "ErrorRecord Helper Methods" {
     }
 
     It "Creates ErrorRecord with correct message and ID when Format-ErrorRecord is called" {
-      Mock -ModuleName Common Format-Object{} -Verifiable
+      Mock -ModuleName Common New-Object{} -Verifiable
       Format-ErrorRecord -Message "testMessage" -ErrorID "testErrorID"
       Should -InvokeVerifiable
     }

--- a/BenchPress/Helpers/BenchPress.Azure/Common.psm1
+++ b/BenchPress/Helpers/BenchPress.Azure/Common.psm1
@@ -162,7 +162,7 @@ function Get-Resource {
     The name of the Resource Group
 
   .PARAMETER ResourceType
-    The type of the Resource (currently support the following:
+    The type of the Resource (currently supports the following:
     ActionGroup
     AKSCluster
     AppServicePlan
@@ -220,19 +220,18 @@ function Confirm-Resource {
 
   if ($null -ne $ConfirmResult.ResourceDetails) {
     $ConfirmResult.Success = $true
+    if ($PropertyKey) {
+      if ($ConfirmResult.ResourceDetails.$PropertyKey -ne $PropertyValue) {
+        $ConfirmResult.Success = $false
+        $ConfirmResult.Error = Format-IncorrectValueError -ExpectedKey $PropertyKey -ExpectedValue $PropertyValue -ActualResult $ConfirmResult.ResourceDetails.$PropertyKey
+      }
+    }
   }
   else {
     $ConfirmResult.Success = $false
     $ConfirmResult.Error = Format-NotExistError -Expected $ResourceName
-    return $ConfirmResult
   }
 
-  if($PropertyKey){
-    if($ConfirmResult.ResourceDetails.$PropertyKey -ne $PropertyValue){
-      $ConfirmResult.Success = $false
-      $ConfirmResult.Error = Format-IncorrectValueError -ExpectedKey $PropertyKey -ExpectedValue $PropertyValue -ActualResult $ConfirmResult.ResourceDetails.$PropertyKey
-    }
-  }
   return $ConfirmResult
 }
 

--- a/BenchPress/Helpers/BenchPress.Azure/Common.psm1
+++ b/BenchPress/Helpers/BenchPress.Azure/Common.psm1
@@ -185,7 +185,7 @@ function Get-Resource {
     Confirm-AzBPResource -ResourceType $resourceType -ResourceName $resourceGroupName
 
   .EXAMPLE
-    Confirm wheter a resource has a property configured correctly (i.e. Resource Group located in West US 3)
+    Confirm whether a resource has a property configured correctly (i.e. Resource Group located in West US 3)
     Confirm-AzBPResource -ResourceType $resourceType -ResourceName $resourceGroupName -PropertyKey "Location" `
                          -PropertyValue "WestUS3"
   .INPUTS
@@ -223,14 +223,14 @@ function Confirm-Resource {
   }
   else {
     $ConfirmResult.Success = $false
-    $ConfirmResult.Error = New-NotExistError -Expected $ResourceName
+    $ConfirmResult.Error = Format-NotExistError -Expected $ResourceName
     return $ConfirmResult
   }
 
   if($PropertyKey){
     if($ConfirmResult.ResourceDetails.$PropertyKey -ne $PropertyValue){
       $ConfirmResult.Success = $false
-      $ConfirmResult.Error = New-IncorrectValueError -ExpectedKey $PropertyKey -ExpectedValue $PropertyValue -ActualResult $ConfirmResult.ResourceDetails.$PropertyKey
+      $ConfirmResult.Error = Format-IncorrectValueError -ExpectedKey $PropertyKey -ExpectedValue $PropertyValue -ActualResult $ConfirmResult.ResourceDetails.$PropertyKey
     }
   }
   return $ConfirmResult
@@ -242,14 +242,14 @@ function Confirm-Resource {
     Private function to create a message and ErrorRecord for when a resource does not exist.
 
   .DESCRIPTION
-    New-NotExistError is a private helper function that can be used to construct a message and ErrorRecord
+    Format-NotExistError is a private helper function that can be used to construct a message and ErrorRecord
     for when a resource does not exist.
 
   .PARAMETER Expected
     The name of the resource that was expected to exist.
 
   .EXAMPLE
-    New-NotExistError -Expected "MyVM"
+    Format-NotExistError -Expected "MyVM"
 
   .INPUTS
     System.String
@@ -257,9 +257,9 @@ function Confirm-Resource {
   .OUTPUTS
     System.Management.Automation.ErrorRecord
 #>
-function New-NotExistError([string]$Expected) {
+function Format-NotExistError([string]$Expected) {
   $Message = "Expected $Expected to exist, but it does not exist."
-  return New-ErrorRecord -Message $Message -ErrorID "BenchPressExistFail"
+  return Format-ErrorRecord -Message $Message -ErrorID "BenchPressExistFail"
 }
 
 <#
@@ -267,7 +267,7 @@ function New-NotExistError([string]$Expected) {
     Private function to create a message and ErrorRecord for when a resource property is not set correctly.
 
   .DESCRIPTION
-    New-IncorrectValueError is a private helper function that can be used to construct a message and ErrorRecord
+    Format-IncorrectValueError is a private helper function that can be used to construct a message and ErrorRecord
     for when a resource property is not set to the expected value.
 
   .PARAMETER ExpectedKey
@@ -280,7 +280,7 @@ function New-NotExistError([string]$Expected) {
     The actual value of the resource property
 
   .EXAMPLE
-    New-IncorrectValueError -ExpectedKey "Location" -ExpectedValue "WestUS3" -ActualValue "EastUS"
+    Format-IncorrectValueError -ExpectedKey "Location" -ExpectedValue "WestUS3" -ActualValue "EastUS"
 
   .INPUTS
     System.String
@@ -288,9 +288,9 @@ function New-NotExistError([string]$Expected) {
   .OUTPUTS
     System.Management.Automation.ErrorRecord
 #>
-function New-IncorrectValueError([string]$ExpectedKey, [string]$ExpectedValue, [string]$ActualValue) {
+function Format-IncorrectValueError([string]$ExpectedKey, [string]$ExpectedValue, [string]$ActualValue) {
   $Message = "Expected $ExpectedKey to be $ExpectedValue, but got $ActualValue"
-  return New-ErrorRecord -Message $Message -ErrorID "BenchPressValueFail"
+  return Format-ErrorRecord -Message $Message -ErrorID "BenchPressValueFail"
 }
 
 <#
@@ -298,7 +298,7 @@ function New-IncorrectValueError([string]$ExpectedKey, [string]$ExpectedValue, [
     Private function to help construct a ErrorRecord.
 
   .DESCRIPTION
-    New-ErrorRecord is a private helper function that can be used to construct an ErrorRecord.
+    Format-ErrorRecord is a private helper function that can be used to construct an ErrorRecord.
 
   .PARAMETER Message
     Message for the ErrorRecord
@@ -307,7 +307,7 @@ function New-IncorrectValueError([string]$ExpectedKey, [string]$ExpectedValue, [
     A string that can be used to uniquily identify the ErrorRecord.
 
   .EXAMPLE
-    New-ErrorRecord -Message $incorrectValueMessage -ErrorID "BenchPressValueFail"
+    Format-ErrorRecord -Message $incorrectValueMessage -ErrorID "BenchPressValueFail"
 
   .INPUTS
     System.String
@@ -315,13 +315,13 @@ function New-IncorrectValueError([string]$ExpectedKey, [string]$ExpectedValue, [
   .OUTPUTS
     System.Management.Automation.ErrorRecord
 #>
-function New-ErrorRecord ([string] $Message, [string]$ErrorID) {
+function Format-ErrorRecord ([string] $Message, [string]$ErrorID) {
   $Exception = [Exception] $Message
   $ErrorCategory = [System.Management.Automation.ErrorCategory]::InvalidResult
   $TargetObject = @{ Message = $Message }
-  $ErrorRecord = New-Object System.Management.Automation.ErrorRecord $Exception, $ErrorID, $ErrorCategory, $TargetObject
+  $ErrorRecord = Format-Object System.Management.Automation.ErrorRecord $Exception, $ErrorID, $ErrorCategory, $TargetObject
   return $ErrorRecord
 }
 
 Export-ModuleMember -Function Get-Resource, Get-ResourceByType, Confirm-Resource, `
-  New-NotExistError, New-IncorrectValueError, New-ErrorRecord
+  Format-NotExistError, Format-IncorrectValueError, Format-ErrorRecord

--- a/BenchPress/Helpers/BenchPress.Azure/Common.psm1
+++ b/BenchPress/Helpers/BenchPress.Azure/Common.psm1
@@ -319,7 +319,7 @@ function Format-ErrorRecord ([string] $Message, [string]$ErrorID) {
   $Exception = [Exception] $Message
   $ErrorCategory = [System.Management.Automation.ErrorCategory]::InvalidResult
   $TargetObject = @{ Message = $Message }
-  $ErrorRecord = Format-Object System.Management.Automation.ErrorRecord $Exception, $ErrorID, $ErrorCategory, $TargetObject
+  $ErrorRecord = New-Object System.Management.Automation.ErrorRecord $Exception, $ErrorID, $ErrorCategory, $TargetObject
   return $ErrorRecord
 }
 

--- a/examples/Common.Tests.ps1
+++ b/examples/Common.Tests.ps1
@@ -58,7 +58,8 @@ Describe 'Use Confirm-AzBPResource to confirm resource and/or properties exist'{
       $containerRegistryName = "testcontaineregistry"
 
       #act
-      $result = Confirm-AzBPResource -ResourceGroupName $resourceGroupName -ResourceType $resourceType -ResourceName $containerRegistryName
+      $result = Confirm-AzBPResource -ResourceGroupName $resourceGroupName -ResourceType $resourceType `
+                  -ResourceName $containerRegistryName
 
       #assert
       $result.Success | Should -Be $true
@@ -73,7 +74,8 @@ Describe 'Use Confirm-AzBPResource to confirm resource and/or properties exist'{
       $expectedValue = "Standard"
 
       #act
-      $result = Confirm-AzBPResource -ResourceGroupName $resourceGroupName -ResourceType $resourceType -ResourceName $containerRegistryName -PropertyKey $property -PropertyValue $expectedValue
+      $result = Confirm-AzBPResource -ResourceGroupName $resourceGroupName -ResourceType $resourceType `
+                  -ResourceName $containerRegistryName -PropertyKey $property -PropertyValue $expectedValue
 
       #assert
       $result.Success | Should -Be $true
@@ -100,7 +102,8 @@ Describe 'Use Confirm-AzBPResource to confirm resource and/or properties exist'{
       $expectedValue = "WestUS3"
 
       #act
-      $result = Confirm-AzBPResource -ResourceType $resourceType -ResourceName $resourceGroupName -PropertyKey $property -PropertyValue $expectedValue
+      $result = Confirm-AzBPResource -ResourceType $resourceType -ResourceName $resourceGroupName `
+                  -PropertyKey $property -PropertyValue $expectedValue
 
       #assert
       $result.Success | Should -Be $true
@@ -114,7 +117,8 @@ Describe 'Use Confirm-AzBPResource to confirm resource and/or properties exist'{
       $sqlServerName = "testserver"
       $resourceType = "SqlServer"
       #act
-      $result = Confirm-AzBPResource -ResourceGroupName $resourceGroupName -ResourceType $resourceType -ResourceName $sqlServerName
+      $result = Confirm-AzBPResource -ResourceGroupName $resourceGroupName -ResourceType $resourceType `
+                  -ResourceName $sqlServerName
 
       #assert
       $result.Success | Should -Be $true

--- a/examples/Common.Tests.ps1
+++ b/examples/Common.Tests.ps1
@@ -48,3 +48,76 @@ Describe 'Verify Resource Exists' {
     $exists | Should -Be $true
   }
 }
+
+Describe 'Use Confirm-AzBPResource to confirm resource and/or properties exist'{
+  Describe 'Verify Container Registry' {
+    it 'Should contain a container registry named testcontaineregistry' {
+      #arrange
+      $resourceGroupName = "testrg"
+      $resourceType = "ContainerRegistry"
+      $containerRegistryName = "testcontaineregistry"
+
+      #act
+      $result = Confirm-AzBPResource -ResourceGroupName $resourceGroupName -ResourceType $resourceType -ResourceName $containerRegistryName
+
+      #assert
+      $result.Success | Should -Be $true
+    }
+
+    it 'Should contain a container registry named testcontaineregistry is Standard' {
+      #arrange
+      $resourceGroupName = "testrg"
+      $resourceType = "ContainerRegistry"
+      $containerRegistryName = "testcontaineregistry"
+      $property = "SkuName"
+      $expectedValue = "Standard"
+
+      #act
+      $result = Confirm-AzBPResource -ResourceGroupName $resourceGroupName -ResourceType $resourceType -ResourceName $containerRegistryName -PropertyKey $property -PropertyValue $expectedValue
+
+      #assert
+      $result.Success | Should -Be $true
+    }
+  }
+
+  Describe 'Verify Resource Group' {
+    it 'Should contain a resource group named testrg' {
+      #arrange
+      $resourceGroupName = "testrg"
+      $resourceType = "ResourceGroup"
+      #act
+      $result = Confirm-AzBPResource -ResourceType $resourceType -ResourceName $resourceGroupName
+
+      #assert
+      $result.Success | Should -Be $true
+    }
+
+    it 'Should contain a a resource group named testrg in WestUS3' {
+      #arrange
+      $resourceGroupName = "testrg"
+      $resourceType = "ResourceGroup"
+      $property = "Location"
+      $expectedValue = "WestUS3"
+
+      #act
+      $result = Confirm-AzBPResource -ResourceType $resourceType -ResourceName $resourceGroupName -PropertyKey $property -PropertyValue $expectedValue
+
+      #assert
+      $result.Success | Should -Be $true
+    }
+  }
+
+  Describe 'Verify SQL Server' {
+    it 'Should contain a SQL Server named testserver' {
+      #arrange
+      $resourceGroupName = "testrg"
+      $sqlServerName = "testserver"
+      $resourceType = "SqlServer"
+      #act
+      $result = Confirm-AzBPResource -ResourceGroupName $resourceGroupName -ResourceType $resourceType -ResourceName $sqlServerName
+
+      #assert
+      $result.Success | Should -Be $true
+    }
+  }
+}


### PR DESCRIPTION
Includes the PoC code that was shown during design session with unit tests and examples introduced.

- Kept the `Confirm-AzBPResource` name. After researching approved verbs, `Confirm` still made the most sense.
- `Confirm-AzBPResource` will handle checking whether a resource exists and also provides functionality checking a property on a resource is set to the correct value

As I was cleaning up my code and running further tests, there were some additional really interesting design questions that came up. They are reflected in #155 and #154. Since these design questions would greatly affect the implementation of `Confirm-AzBPResource`, I understand if we would want to hold off on merging this until we get a better idea of how to proceed on those two design questions.