### PR TITLE
Remove dated functions and update getting-started.md

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -74,13 +74,18 @@ The easiest way to get started with BenchPress is to use the files in the `examp
     Starting discovery in 1 files.
     Discovery found 3 tests in 44ms.
     Running tests.
-    Get-AzContainerRegistry: The Resource 'Microsoft.ContainerRegistry/registries/acrbenchpresstest1' under resource group 'rg-test' was not found.
+    Get-AzContainerRegistry: The Resource
+    'Microsoft.ContainerRegistry/registries/acrbenchpresstest1' under
+    resource group 'rg-test' was not found.
     For more details please go to https://aka.ms/ARMResourceNotFoundFix
     [-] Verify Container Registry.Should contain a container registry with the given name 894ms (893ms|1ms)
     Expected $true, but got $false.
-    at $result.Success | Should -Be $true, BenchPress\benchpress\examples\ContainerRegistry.Tests.ps1:15
+    at $result.Success | Should -Be $true,
+    BenchPress\benchpress\examples\ContainerRegistry.Tests.ps1:15
     at <ScriptBlock>, BenchPress\benchpress\examples\ContainerRegistry.Tests.ps1:15
-    New-AzResourceGroupDeployment: 3:01:24 PM - Error: Code=ResourceGroupNotFound; Message=Resource group 'rg-test' could not be found.
+    New-AzResourceGroupDeployment: 3:01:24 PM -
+    Error: Code=ResourceGroupNotFound; Message=Resource group
+    'rg-test' could not be found.
     New-AzResourceGroupDeployment: The deployment validation failed
     [-] Spin up , Tear down Container Registry.Should deploy a bicep file. 4.52s (4.52s|1ms)
     Expected 'Succeeded', but got $null.
@@ -176,8 +181,10 @@ Describe 'Verify Container Registry' {
 ```
 
 This test uses the `Confirm-AzBPContainerRegistry` helper from BenchPress. `Confirm-AzBPContainerRegistry` returns a `ConfirmResult` object
-with information about the success of the call, resource details, authentication data and an error record.
-Assuming the container registry exists, we assert that the object returned by `Confirm-AzBPContainerRegistry` is successful.
+with information about the success of the call,
+resource details, authentication data and an error record.
+Assuming the container registry exists, we assert that
+the object returned by `Confirm-AzBPContainerRegistry` is successful.
 
 Let's look at the second `Describe` block:
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -180,7 +180,8 @@ Describe 'Verify Container Registry' {
 }
 ```
 
-This test uses the `Confirm-AzBPContainerRegistry` helper from BenchPress. `Confirm-AzBPContainerRegistry` returns a `ConfirmResult` object
+This test uses the `Confirm-AzBPContainerRegistry` helper
+from BenchPress. `Confirm-AzBPContainerRegistry` returns a `ConfirmResult` object
 with information about the success of the call,
 resource details, authentication data and an error record.
 Assuming the container registry exists, we assert that

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -68,31 +68,26 @@ The easiest way to get started with BenchPress is to use the files in the `examp
    `ContainerRegistry.Tests.ps1` as our examples. To run the `ContainerRegistry.Tests.ps1` tests, execute
    `.\ContainerRegistry.Tests.ps1` or `Invoke-Pester -Path .\ContainerRegistry.Tests.ps1`.
 
-1. Your test results will most likely be three test failures:
+1. Your test results will most likely be two test failures:
 
    ```PowerShell
-   Starting discovery in 1 files.
-   Discovery found 3 tests in 40ms.
-   Running tests.
-   Get-AzContainerRegistry: Resource group 'rg-test' could not be found.
-   [-] Verify Container Registry Exists.Should contain a container registry with the given name 537ms (530ms|7ms)
-    Expected a value, but got $null or empty.
-    at $exists | Should -Not -BeNullOrEmpty, \benchpress\examples\ContainerRegistry.Tests.ps1:15
-    at <ScriptBlock>, \benchpress\examples\ContainerRegistry.Tests.ps1:15
-   Get-AzContainerRegistry: Resource group 'rg-test' could not be found.
-   [-] Verify Container Registry Exists.Should contain a container registry with the given name 213ms (213ms|0ms)
+    Starting discovery in 1 files.
+    Discovery found 3 tests in 44ms.
+    Running tests.
+    Get-AzContainerRegistry: The Resource 'Microsoft.ContainerRegistry/registries/acrbenchpresstest1' under resource group 'rg-test' was not found.
+    For more details please go to https://aka.ms/ARMResourceNotFoundFix
+    [-] Verify Container Registry.Should contain a container registry with the given name 894ms (893ms|1ms)
     Expected $true, but got $false.
-    at $exists | Should -Be $true, \benchpress\examples\ContainerRegistry.Tests.ps1:29
-    at <ScriptBlock>, \benchpress\examples\ContainerRegistry.Tests.ps1:29
-   New-AzResourceGroupDeployment: 1:48:19 PM - Error: Code=ResourceGroupNotFound; Message=Resource group 'rg-test'
-   could not be found.
-   New-AzResourceGroupDeployment: The deployment validation failed
-   [-] Spin up , Tear down Container Registry.Should deploy a bicep file. 6.01s (6.01s|0ms)
+    at $result.Success | Should -Be $true, BenchPress\benchpress\examples\ContainerRegistry.Tests.ps1:15
+    at <ScriptBlock>, BenchPress\benchpress\examples\ContainerRegistry.Tests.ps1:15
+    New-AzResourceGroupDeployment: 3:01:24 PM - Error: Code=ResourceGroupNotFound; Message=Resource group 'rg-test' could not be found.
+    New-AzResourceGroupDeployment: The deployment validation failed
+    [-] Spin up , Tear down Container Registry.Should deploy a bicep file. 4.52s (4.52s|1ms)
     Expected 'Succeeded', but got $null.
-    at $deployment.ProvisioningState | Should -Be "Succeeded", \benchpress\examples\ContainerRegistry.Tests.ps1:47
-    at <ScriptBlock>, \benchpress\examples\ContainerRegistry.Tests.ps1:47
-   Tests completed in 4.74s
-   Tests Passed: 0, Failed: 3, Skipped: 0 NotRun: 0
+    at $deployment.ProvisioningState | Should -Be "Succeeded", BenchPress\benchpress\examples\ContainerRegistry.Tests.ps1:50
+    at <ScriptBlock>, BenchPress\benchpress\examples\ContainerRegistry.Tests.ps1:50
+    Tests completed in 6.3s
+    Tests Passed: 1, Failed: 2, Skipped: 0 NotRun: 0
    ```
 
 ## Walkthrough of Test File
@@ -105,31 +100,34 @@ BeforeAll {
   Import-Module "../BenchPress/Helpers/Azure/BenchPress.Azure.psd1"
 }
 
-Describe 'Verify Container Registry Exists' {
+Describe 'Verify Container Registry' {
   it 'Should contain a container registry with the given name' {
     #arrange
     $rgName = "rg-test"
     $acrName = "acrbenchpresstest1"
 
     #act
-    $exists = Get-AzBPContainerRegistry -ResourceGroupName $rgName -Name $acrName
+    $result = Confirm-AzBPContainerRegistry -ResourceGroupName $rgName -Name $acrName
 
     #assert
-    $exists | Should -Not -BeNullOrEmpty
+    $result.Success | Should -Be $true
   }
 }
 
-Describe 'Verify Container Registry Exists' {
-  it 'Should contain a container registry with the given name' {
+Describe 'Verify Container Registry Does Not Exist' {
+  it 'Should not contain a container registry with the given name' {
     #arrange
     $rgName = "rg-test"
     $acrName = "acrbenchpresstest1"
 
     #act
-    $exists = Get-AzBPContainerRegistryExist -ResourceGroupName $rgName -Name $acrName
+    # The '-ErrorAction SilentlyContinue' command suppresses all errors.
+    # In this test, it will suppress the error message when a resource cannot be found.
+    # Remove this field to see all errors.
+    $result = Confirm-AzBPContainerRegistry -ResourceGroupName $rgName -Name $acrName -ErrorAction SilentlyContinue
 
     #assert
-    $exists | Should -Be $true
+    $result.Success | Should -Be $false
   }
 }
 
@@ -144,8 +142,7 @@ Describe 'Spin up , Tear down Container Registry' {
     }
 
     #act
-    $deployment = Deploy-AzBPBicepFeature -BicepPath $bicepPath -Params $params `
-                  -ResourceGroupName $resourceGroupName
+    $deployment = Deploy-AzBPBicepFeature -BicepPath $bicepPath -Params $params -ResourceGroupName $resourceGroupName
 
     #assert
     $deployment.ProvisioningState | Should -Be "Succeeded"
@@ -163,48 +160,48 @@ BenchPress module in the `BeforeAll` block.
 Let's look at the first `Describe` block:
 
 ```PowerShell
-Describe 'Verify Container Registry Exists' {
+Describe 'Verify Container Registry' {
   it 'Should contain a container registry with the given name' {
     #arrange
     $rgName = "rg-test"
     $acrName = "acrbenchpresstest1"
 
     #act
-    $exists = Get-AzBPContainerRegistry -ResourceGroupName $rgName -Name $acrName
+    $result = Confirm-AzBPContainerRegistry -ResourceGroupName $rgName -Name $acrName
 
     #assert
-    $exists | Should -Not -BeNullOrEmpty
+    $result.Success | Should -Be $true
   }
 }
 ```
 
-This test uses the `Get-AzBPContainerRegistry` helper from BenchPress. `Get-AzBPContainerRegistry` returns an object
-representing the container registry in the specified resource group and with the specified container registry name.
-Assuming the container registry exists, we assert that the object returned by `Get-AzBPContainerRegistry` is not null
-or empty.
+This test uses the `Confirm-AzBPContainerRegistry` helper from BenchPress. `Confirm-AzBPContainerRegistry` returns a `ConfirmResult` object
+with information about the success of the call, resource details, authentication data and an error record.
+Assuming the container registry exists, we assert that the object returned by `Confirm-AzBPContainerRegistry` is successful.
 
 Let's look at the second `Describe` block:
 
 ```PowerShell
-Describe 'Verify Container Registry Exists' {
-  it 'Should contain a container registry with the given name' {
+Describe 'Verify Container Registry Does Not Exist' {
+  it 'Should not contain a container registry with the given name' {
     #arrange
     $rgName = "rg-test"
     $acrName = "acrbenchpresstest1"
 
     #act
-    $exists = Get-AzBPContainerRegistryExist -ResourceGroupName $rgName -Name $acrName
+    # The '-ErrorAction SilentlyContinue' command suppresses all errors.
+    # In this test, it will suppress the error message when a resource cannot be found.
+    # Remove this field to see all errors.
+    $result = Confirm-AzBPContainerRegistry -ResourceGroupName $rgName -Name $acrName -ErrorAction SilentlyContinue
 
     #assert
-    $exists | Should -Be $true
+    $result.Success | Should -Be $false
   }
 }
 ```
 
-This test looks very similar to the first test, except it is using the `Get-AzBPContainerRegistryExist` helper instead.
-This helper doesn't return the object representing the Container Registry, but instead returns true if the Container
-Registry exists and false if it does not exists. Assuming the container registry exists, we assert that the return
-should be true.
+This test looks very similar to the first test, except it checks that the container registry does not exist.
+Take note of the `-ErrorAction SilentlyContinue` comment.
 
 Now let's look at the third `Describe` block:
 
@@ -240,7 +237,7 @@ the deployed resources using the `Remove-AzBPBicepFeature` helper.
 
 Now that we've done a walkthrough of the three tests, let's fix them.
 
-The first two tests assumed that our container registry was already deployed to a resource group. However, we
+The first test assumed that our container registry was already deployed to a resource group. However, we
 never deployed the `containerRegistry.bicep` file ourselves! The third test assumed we had an existing resource group
 to deploy to, but we never deployed that either! Let's go ahead and fix these assumptions now:
 

--- a/examples/AKSCluster.Tests.ps1
+++ b/examples/AKSCluster.Tests.ps1
@@ -26,10 +26,10 @@ Describe 'Verify AKS Cluster Does Not Exist' {
     # The '-ErrorAction SilentlyContinue' command suppresses all errors.
     # In this test, it will suppress the error message when a resource cannot be found.
     # Remove this field to see all errors.
-    $exists = Get-AzBPAKSClusterExist -ResourceGroupName $resourceGroupName -AKSName $aksName -ErrorAction SilentlyContinue
+    $result = Confirm-AzBPAksCluster -ResourceGroupName $resourceGroupName -AKSName $aksName -ErrorAction SilentlyContinue
 
     #assert
-    $exists | Should -Be $false
+    $result.Success | Should -Be $false
   }
 }
 

--- a/examples/ActionGroup.Tests.ps1
+++ b/examples/ActionGroup.Tests.ps1
@@ -26,15 +26,15 @@ Describe 'Verify Action Group Does Not Exist' {
     # The '-ErrorAction SilentlyContinue' command suppresses all errors.
     # In this test, it will suppress the error message when a resource cannot be found.
     # Remove this field to see all errors.
-    $exists = Get-AzBPActionGroupExist -ResourceGroupName $resourceGroupName -ActionGroupName $actionGroupName -ErrorAction SilentlyContinue
+    $result = Confirm-AzBPActionGroup -ResourceGroupName $resourceGroupName -ActionGroupName $actionGroupName -ErrorAction SilentlyContinue
 
     #assert
-    $exists | Should -Be $false
+    $result.Success | Should -Be $false
   }
 }
 
 Describe 'Spin up , Tear down Action Group' {
-  it 'Should deploy a bicep file.' {
+  it 'Should deploy a bi  cep file.' {
     #arrange
     $resourceGroupName = "test-rg"
     $bicepPath = "./actionGroup.bicep"

--- a/examples/ActionGroup.Tests.ps1
+++ b/examples/ActionGroup.Tests.ps1
@@ -34,7 +34,7 @@ Describe 'Verify Action Group Does Not Exist' {
 }
 
 Describe 'Spin up , Tear down Action Group' {
-  it 'Should deploy a bi  cep file.' {
+  it 'Should deploy a bicep file.' {
     #arrange
     $resourceGroupName = "test-rg"
     $bicepPath = "./actionGroup.bicep"

--- a/examples/AppServicePlan.Tests.ps1
+++ b/examples/AppServicePlan.Tests.ps1
@@ -26,10 +26,10 @@ Describe 'Verify App Service Plan Does Not Exist' {
         # The '-ErrorAction SilentlyContinue' command suppresses all errors.
         # In this test, it will suppress the error message when a resource cannot be found.
         # Remove this field to see all errors.
-        $exists = Get-AzBPAppServicePlanExist -ResourceGroupName $rgName -AppServicePlanName $appServicePlanName -ErrorAction SilentlyContinue
+        $result = Confirm-AzBPAppServicePlan -ResourceGroupName $rgName -AppServicePlanName $appServicePlanName -ErrorAction SilentlyContinue
 
         #assert
-        $exists | Should -Be $false
+        $result.Success | Should -Be $false
     }
 }
 

--- a/examples/ContainerRegistry.Tests.ps1
+++ b/examples/ContainerRegistry.Tests.ps1
@@ -36,7 +36,7 @@ Describe 'Verify Container Registry Does Not Exist' {
 Describe 'Spin up , Tear down Container Registry' {
   it 'Should deploy a bicep file.' {
     #arrange
-    $resourceGroupName = "rg-test2"
+    $resourceGroupName = "rg-test"
     $bicepPath = "./containerRegistry.bicep"
     $params = @{
       name           = "acrbenchpresstest2"

--- a/examples/ContainerRegistry.Tests.ps1
+++ b/examples/ContainerRegistry.Tests.ps1
@@ -26,17 +26,17 @@ Describe 'Verify Container Registry Does Not Exist' {
     # The '-ErrorAction SilentlyContinue' command suppresses all errors.
     # In this test, it will suppress the error message when a resource cannot be found.
     # Remove this field to see all errors.
-    $exists = Get-AzBPContainerRegistryExist -ResourceGroupName $rgName -Name $acrName -ErrorAction SilentlyContinue
+    $result = Confirm-AzBPContainerRegistry -ResourceGroupName $rgName -Name $acrName -ErrorAction SilentlyContinue
 
     #assert
-    $exists | Should -Be $false
+    $result.Success | Should -Be $false
   }
 }
 
 Describe 'Spin up , Tear down Container Registry' {
   it 'Should deploy a bicep file.' {
     #arrange
-    $resourceGroupName = "rg-test"
+    $resourceGroupName = "rg-test2"
     $bicepPath = "./containerRegistry.bicep"
     $params = @{
       name           = "acrbenchpresstest2"

--- a/examples/KeyVault.Tests.ps1
+++ b/examples/KeyVault.Tests.ps1
@@ -54,10 +54,10 @@ Describe 'Verify KeyVault Does Not Exist' {
     # The '-ErrorAction SilentlyContinue' command suppresses all errors.
     # In this test, it will suppress the error message when a resource cannot be found.
     # Remove this field to see all errors.
-    $exists = Get-AzBPKeyVaultExist -ResourceGroupName $rgName -Name $kvName -ErrorAction SilentlyContinue
+    $result = Confirm-AzBPKeyVault -ResourceGroupName $rgName -Name $kvName -ErrorAction SilentlyContinue
 
     #assert
-    $exists | Should -Be $false
+    $result.Success | Should -Be $false
   }
 }
 

--- a/examples/ResourceGroup.Tests.ps1
+++ b/examples/ResourceGroup.Tests.ps1
@@ -24,10 +24,10 @@ Describe 'Verify Resource Group Does Not Exist' {
     # The '-ErrorAction SilentlyContinue' command suppresses all errors.
     # In this test, it will suppress the error message when a resource cannot be found.
     # Remove this field to see all errors.
-    $exists = Get-AzBPResourceGroupExist -ResourceGroupName $rgName -ErrorAction SilentlyContinue
+    $result = Confirm-AzBPResourceGroup -ResourceGroupName $rgName -ErrorAction SilentlyContinue
 
     #assert
-    $exists | Should -Be $false
+    $result.Success | Should -Be $false
   }
 }
 

--- a/examples/SqlDatabase.Tests.ps1
+++ b/examples/SqlDatabase.Tests.ps1
@@ -42,10 +42,10 @@ Describe 'Verify Sql Database Does Not Exist' {
         # The '-ErrorAction SilentlyContinue' command suppresses all errors.
         # In this test, it will suppress the error message when a resource cannot be found.
         # Remove this field to see all errors.
-        $exists =  Get-AzBPSqlDatabaseExist -ResourceGroupName $rgName -DatabaseName $databaseName -ServerName $serverName -ErrorAction SilentlyContinue
+        $result =  Confirm-AzBPSqlDatabase -ResourceGroupName $rgName -DatabaseName $databaseName -ServerName $serverName -ErrorAction SilentlyContinue
 
         #assert
-        $exists | Should -Be $false
+        $result.Success | Should -Be $false
     }
 }
 

--- a/examples/SqlServer.Tests.ps1
+++ b/examples/SqlServer.Tests.ps1
@@ -26,10 +26,10 @@ Describe 'Verify Sql Server Does Not Exist' {
         # The '-ErrorAction SilentlyContinue' command suppresses all errors.
         # In this test, it will suppress the error message when a resource cannot be found.
         # Remove this field to see all errors.
-        $exists = Get-AzBPSqlServerExist -ResourceGroupName $rgName -ServerName $serverName -ErrorAction SilentlyContinue
+        $result = Confirm-AzBPSqlServer -ResourceGroupName $rgName -ServerName $serverName -ErrorAction SilentlyContinue
 
         #assert
-        $exists | Should -Be $false
+        $result.Success | Should -Be $false
     }
 }
 

--- a/examples/VirtualMachine.Tests.ps1
+++ b/examples/VirtualMachine.Tests.ps1
@@ -26,10 +26,10 @@ Describe 'Verify Virtual Machine Does Not Exist' {
         # The '-ErrorAction SilentlyContinue' command suppresses all errors.
         # In this test, it will suppress the error message when a resource cannot be found.
         # Remove this field to see all errors.
-        $exists = Get-AzBPVirtualMachineExist -ResourceGroupName $rgName -VirtualMachineName $vmName -ErrorAction SilentlyContinue
+        $result = Confirm-AzBPVirtualMachine -ResourceGroupName $rgName -VirtualMachineName $vmName -ErrorAction SilentlyContinue
 
         #assert
-        $exists | Should -Be $false
+        $result.Success | Should -Be $false
     }
 }
 

--- a/examples/WebApp.Tests.ps1
+++ b/examples/WebApp.Tests.ps1
@@ -26,10 +26,10 @@ Describe 'Verify Web App Does Not Exist' {
         # The '-ErrorAction SilentlyContinue' command suppresses all errors.
         # In this test, it will suppress the error message when a resource cannot be found.
         # Remove this field to see all errors.
-        $exists = Get-AzBPWebAppExist -ResourceGroupName $rgName -WebAppName $webappName -ErrorAction SilentlyContinue
+        $result = Confirm-AzBPWebApp -ResourceGroupName $rgName -WebAppName $webappName -ErrorAction SilentlyContinue
 
         #assert
-        $exists | Should -Be $false
+        $result.Success | Should -Be $false
     }
 }
 


### PR DESCRIPTION
With change to `Confirm-` resource, we don't need the exist functions anymore.

Updated `getting-started.md` with up-to-date function calls and errors