### PR TITLE
Allow for ability to check properties that are stored in arrays

### DIFF
--- a/BenchPress/Helpers/BenchPress.Azure/Common.Tests.ps1
+++ b/BenchPress/Helpers/BenchPress.Azure/Common.Tests.ps1
@@ -63,10 +63,14 @@ Describe "Confirm-Resource" {
       Mock -ModuleName Common Format-ErrorRecord{}
       Mock -ModuleName Common Format-IncorrectValueError{}
       Mock -ModuleName Common Format-PropertyDoesNotExistError{}
+      $ConfirmResult = [ConfirmResult]::new(
+        @{
+          TestKey = "TestValue"
+          TestArray = @(@{AnotherKey = "AnotherValue"})
+        }, $null)
     }
 
     It "Calls Get-ResourceByType; returns true when Get-ResourceByType returns a Success ConfirmResult." {
-      $ConfirmResult = [ConfirmResult]::new("resource", $null)
       Mock -ModuleName Common Get-ResourceByType{ $ConfirmResult } -Verifiable
 
       $result = Confirm-Resource -ResourceType "ResourceGroup" -ResourceName "mockResourceName"
@@ -78,11 +82,23 @@ Describe "Confirm-Resource" {
     }
 
     It "Calls Get-ResourceByType; returns true when property matches value." {
-      $ConfirmResult = [ConfirmResult]::new(@{TestKey = "RightValue"}, $null)
       Mock -ModuleName Common Get-ResourceByType{ $ConfirmResult } -Verifiable
 
       $result = Confirm-Resource -ResourceType "ResourceGroup" -ResourceName "mockResourceName" `
-        -PropertyKey "TestKey" -PropertyValue "RightValue"
+        -PropertyKey "TestKey" -PropertyValue "TestValue"
+
+      Should -InvokeVerifiable
+      Should -Invoke -ModuleName Common -CommandName "Format-NotExistError" -Times 0
+      Should -Invoke -ModuleName Common -CommandName "Format-IncorrectValueError" -Times 0
+
+      $result.Success | Should -Be $true
+    }
+
+    It "Calls Get-ResourceByType; returns true when accessing property in array and matches value." {
+      Mock -ModuleName Common Get-ResourceByType{ $ConfirmResult } -Verifiable
+
+      $result = Confirm-Resource -ResourceType "ResourceGroup" -ResourceName "mockResourceName" `
+        -PropertyKey "TestArray[0].AnotherKey" -PropertyValue "AnotherValue"
 
       Should -InvokeVerifiable
       Should -Invoke -ModuleName Common -CommandName "Format-NotExistError" -Times 0
@@ -103,11 +119,10 @@ Describe "Confirm-Resource" {
     }
 
     It "Calls Get-ResourceByType and Format-IncorrectValueError; returns false when property does not match value." {
-      $ConfirmResult = [ConfirmResult]::new(@{TestKey = "WrongValue"}, $null)
       Mock -ModuleName Common Get-ResourceByType{ $ConfirmResult } -Verifiable
 
       $result = Confirm-Resource -ResourceType "ResourceGroup" -ResourceName "mockResourceName" `
-        -PropertyKey "TestKey" -PropertyValue "RightValue"
+        -PropertyKey "TestKey" -PropertyValue "WrongValue"
 
       Should -InvokeVerifiable
       Should -Invoke -ModuleName Common -CommandName "Format-NotExistError" -Times 0
@@ -116,8 +131,19 @@ Describe "Confirm-Resource" {
       $result.Success | Should -Be $false
     }
 
+    It "Calls Get-ResourceByType; returns false when indexing incorrectly into property array" {
+      Mock -ModuleName Common Get-ResourceByType{ $ConfirmResult } -Verifiable
+
+      $result = Confirm-Resource -ResourceType "ResourceGroup" -ResourceName "mockResourceName" `
+        -PropertyKey "WrongArray[0].AnotherKey" -PropertyValue "AnotherValue"
+
+      Should -InvokeVerifiable
+
+      $result.Success | Should -Be $false
+      $result.ErrorRecord | Should -Not -Be $null
+    }
+
     It "Calls Get-ResourceByType and Format-PropertyDoesNotExistError; returns false when property does not exist." {
-      $ConfirmResult = [ConfirmResult]::new(@{TestKey = "TestValue"}, $null)
       Mock -ModuleName Common Get-ResourceByType{ $ConfirmResult } -Verifiable
 
       $result = Confirm-Resource -ResourceType "ResourceGroup" -ResourceName "mockResourceName" `

--- a/BenchPress/Helpers/BenchPress.Azure/Common.Tests.ps1
+++ b/BenchPress/Helpers/BenchPress.Azure/Common.Tests.ps1
@@ -63,7 +63,7 @@ Describe "Confirm-Resource" {
       Mock -ModuleName Common Format-ErrorRecord{}
       Mock -ModuleName Common Format-IncorrectValueError{}
       Mock -ModuleName Common Format-PropertyDoesNotExistError{}
-      $ConfirmResult = [ConfirmResult]::new(
+      $script:ConfirmResult = [ConfirmResult]::new(
         @{
           TestKey = "TestValue"
           TestArray = @(@{AnotherKey = "AnotherValue"})

--- a/BenchPress/Helpers/BenchPress.Azure/Common.psm1
+++ b/BenchPress/Helpers/BenchPress.Azure/Common.psm1
@@ -262,14 +262,14 @@ function Confirm-Resource {
             $ActualValue = $ActualValue[$Key]
           } catch {
             $ErrorRecord = $_
-            $ConfirmResult = [ConfirmResult]::new($ErrorRecord, $ConnectResults.AuthenticationData)
+            $ConfirmResult = [ConfirmResult]::new($ErrorRecord, $null)
           }
         }
         else{
           $ActualValue = $ActualValue.$Key
         }
       }
-      if ($ActualValue -ne $PropertyValue) {
+      if ($ActualValue -ne $PropertyValue -and $ConfirmResult.Success -ne $false) {
         if ($ActualValue) {
           $ErrorRecord = `
             Format-IncorrectValueError -ExpectedKey $PropertyKey `

--- a/BenchPress/Helpers/BenchPress.Azure/Common.psm1
+++ b/BenchPress/Helpers/BenchPress.Azure/Common.psm1
@@ -255,9 +255,19 @@ function Confirm-Resource {
   } elseif ($ConfirmResult.Success) {
     if ($PropertyKey) {
       $ActualValue = $ConfirmResult.ResourceDetails
-      $Keys = $PropertyKey.Split(".")
+      $Keys = ($PropertyKey -split '[\[\]\.]').Where({ $_ -ne "" })
       foreach($Key in $Keys){
-        $ActualValue = $ActualValue.$Key
+        if($Key -match "^\d+$"){
+          try {
+            $ActualValue = $ActualValue[$Key]
+          } catch {
+            $ErrorRecord = $_
+            $ConfirmResult = [ConfirmResult]::new($ErrorRecord, $ConnectResults.AuthenticationData)
+          }
+        }
+        else{
+          $ActualValue = $ActualValue.$Key
+        }
       }
       if ($ActualValue -ne $PropertyValue) {
         if ($ActualValue) {

--- a/BenchPress/Helpers/BenchPress.Azure/Common.psm1
+++ b/BenchPress/Helpers/BenchPress.Azure/Common.psm1
@@ -263,6 +263,7 @@ function Confirm-Resource {
           } catch {
             $ErrorRecord = $_
             $ConfirmResult = [ConfirmResult]::new($ErrorRecord, $null)
+            break
           }
         }
         else{

--- a/BenchPress/Helpers/BenchPress.Azure/Common.psm1
+++ b/BenchPress/Helpers/BenchPress.Azure/Common.psm1
@@ -91,7 +91,7 @@ function Get-ResourceByType {
     ContainerRegistry { return Confirm-ContainerRegistry -Name $ResourceName -ResourceGroupName $ResourceGroupName }
     KeyVault { return Confirm-KeyVault -Name $ResourceName -ResourceGroupName $ResourceGroupName }
     ResourceGroup { return Confirm-ResourceGroup -ResourceGroupName $ResourceName }
-    SqlDatabase { return Confirm-SqlDatabase -ServerName $ServerName -DatabaseName $ResourceName -ResourceGroupName $ResourceGroupName}
+    SqlDatabase { return Confirm-SqlDatabase -ServerName $ServerName -DatabaseName $ResourceName -ResourceGroupName $ResourceGroupName }
     SqlServer { return Confirm-SqlServer -ServerName $ResourceName -ResourceGroupName $ResourceGroupName }
     VirtualMachine { return Confirm-VirtualMachine -VirtualMachineName $ResourceName -ResourceGroupName $ResourceGroupName }
     WebApp { return Confirm-WebApp -WebAppName $ResourceName -ResourceGroupName $ResourceGroupName }
@@ -242,9 +242,9 @@ function Confirm-Resource {
 
   $ResourceParams = @{
     ResourceGroupName = $ResourceGroupName
-    ResourceName = $ResourceName
-    ResourceType = $ResourceType
-    ServerName = $ServerName
+    ResourceName      = $ResourceName
+    ResourceType      = $ResourceType
+    ServerName        = $ServerName
   }
 
   $ConfirmResult = Get-ResourceByType @ResourceParams
@@ -252,21 +252,25 @@ function Confirm-Resource {
   if ($null -eq $ConfirmResult) {
     $ErrorRecord = Format-ErrorRecord -Message "ResourceType is invalid" -ErrorID "InvalidResourceType"
     $ConfirmResult = [ConfirmResult]::new($ErrorRecord, $null)
-  } elseif ($ConfirmResult.Success) {
+  }
+  elseif ($ConfirmResult.Success) {
     if ($PropertyKey) {
       $ActualValue = $ConfirmResult.ResourceDetails
+      # Split property path on open and close square brackets and periods. Remove empty items from array.
       $Keys = ($PropertyKey -split '[\[\]\.]').Where({ $_ -ne "" })
-      foreach($Key in $Keys){
-        if($Key -match "^\d+$"){
+      foreach ($Key in $Keys) {
+        # If key is a numerical value, index into array
+        if ($Key -match "^\d+$") {
           try {
             $ActualValue = $ActualValue[$Key]
-          } catch {
+          }
+          catch {
             $ErrorRecord = $_
             $ConfirmResult = [ConfirmResult]::new($ErrorRecord, $null)
             break
           }
         }
-        else{
+        else {
           $ActualValue = $ActualValue.$Key
         }
       }
@@ -274,8 +278,8 @@ function Confirm-Resource {
         if ($ActualValue) {
           $ErrorRecord = `
             Format-IncorrectValueError -ExpectedKey $PropertyKey `
-                                       -ExpectedValue $PropertyValue `
-                                       -ActualValue $ActualValue
+            -ExpectedValue $PropertyValue `
+            -ActualValue $ActualValue
           $ConfirmResult = [ConfirmResult]::new($ErrorRecord, $null)
         }
         else {

--- a/examples/Common.Tests.ps1
+++ b/examples/Common.Tests.ps1
@@ -173,7 +173,7 @@ Describe 'Use Confirm-AzBPResource to confirm resource and/or properties exist'{
       $result.Success | Should -Be $true
     }
 
-    it 'Should contain a key vault named with an access policy for testsp service principal' {
+    it 'Should contain a key vault named testkv with an access policy for testsp service principal' {
       #arrange
       $params = @{
         ResourceGroupName = "testrg";

--- a/examples/Common.Tests.ps1
+++ b/examples/Common.Tests.ps1
@@ -157,6 +157,38 @@ Describe 'Use Confirm-AzBPResource to confirm resource and/or properties exist'{
       $result.Success | Should -Be $true
     }
   }
+
+  Describe 'Verify Key Vault' {
+    it 'Should contain a key vault named testkv' {
+      #arrange
+      $params = @{
+        ResourceGroupName = "testrg";
+        ResourceType = "KeyVault";
+        ResourceName = "testkv";
+      }
+      #act
+      $result = Confirm-AzBPResource @params
+
+      #assert
+      $result.Success | Should -Be $true
+    }
+
+    it 'Should contain a key vault named with an access policy for testsp service principal' {
+      #arrange
+      $params = @{
+        ResourceGroupName = "testrg";
+        ResourceType = "KeyVault";
+        ResourceName = "testkv";
+        PropertyKey = "AccessPolicies[1].DisplayName";
+        PropertyValue = "testsp (<your-testsp-appid>)"
+      }
+      #act
+      $result = Confirm-AzBPResource @params
+
+      #assert
+      $result.Success | Should -Be $true
+    }
+  }
 }
 
 Describe 'Verify Resource Group Does Not Exist' {


### PR DESCRIPTION
This PR addresses the discussion that came about on #162. It specifically addresses [this discussion](https://github.com/Azure/benchpress/pull/162#issuecomment-1440603361).

User's can now confirm properties if a property is stored in an array (i.e. access policies on a key vault). However, this approach does put the onus on the user to know the exact index to use.

Closes #165