### PR TITLE
#196 Fix broken GitHub Actions from the structure refactor. (v2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Publish AzBP Module locally
         shell: pwsh
         run: |
+          Install-Module -Name Az -Scope CurrentUser -Repository PSGallery -Force
           Publish-Module -Path ./BenchPress.Azure -Repository LocalFeedPSRepo -Verbose
       - name: Install AzBP Module from the repository
         shell: pwsh
@@ -92,6 +93,7 @@ jobs:
       - name: Generate docs
         shell: pwsh
         run: |
+          Install-Module -Name Az -Scope CurrentUser -Repository PSGallery -Force
           Import-Module ./BenchPress.Azure/BenchPress.Azure.psd1
           New-MarkdownHelp -Module BenchPress.Azure -OutputFolder ./docs
       - name: If there are changes push the branch

--- a/Modules/BenchPress.Azure/BenchPress.Azure.psd1
+++ b/Modules/BenchPress.Azure/BenchPress.Azure.psd1
@@ -44,6 +44,9 @@
       ReleaseNotes = ""
       Prerelease = ""
       RequireLicenseAcceptance = $false
+      ExternalModuleDependencies = @(
+        "Az"
+      )
     }
   }
   HelpInfoURI = "https://github.com/Azure/benchpress/"


### PR DESCRIPTION
Installing Az before running `Test-ModuleManifest` and before generating the docs.

Also added `Az` as an external dependency.