### PR TITLE
Azure Dashboard Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
         run: |
           Install-Module -Name Az -Scope CurrentUser -Repository PSGallery -Force
           Install-Module -Name Az.App -Scope CurrentUser -Repository PSGallery -Force
+          Install-Module -Name Az.Portal -Scope CurrentUser -Repository PSGallery -Force
           Publish-Module -Path ./BenchPress.Azure -Repository LocalFeedPSRepo -Verbose
       - name: Install AzBP Module from the repository
         shell: pwsh

--- a/.github/workflows/pr-powershell.yml
+++ b/.github/workflows/pr-powershell.yml
@@ -25,6 +25,7 @@ jobs:
           Set-PSRepository PSGallery -InstallationPolicy Trusted
           Install-Module Az -ErrorAction Stop
           Install-Module Az.App -ErrorAction Stop
+          Install-Module Az.Portal -ErrorAction Stop
           Install-Module Pester -ErrorAction Stop
       - name: Run PowerShell Unit Tests
         shell: pwsh

--- a/BenchPress/Generators/ResourceTypes/PortalDashboard.cs
+++ b/BenchPress/Generators/ResourceTypes/PortalDashboard.cs
@@ -1,0 +1,22 @@
+namespace Generators.ResourceTypes;
+
+public class PortalDashboard : ResourceType
+{
+    public PortalDashboard() { }
+
+    public override string Id => "Microsoft.Portal/dashboards";
+    public override string FullName => Id;
+    public override string FriendlyName => "Portal Dashboard";
+    public override string Prefix => "pd";
+    public override string FunctionPrefix => "PortalDashboard";
+
+    public override IEnumerable<KeyValuePair<string, object>> GetResourceParameters(TestMetadata m)
+    {
+        return new[]
+        {
+            Param("ResourceType", "PortalDashboard"),
+            Param("ResourceName", m.ResourceName),
+            Param("ResourceGroupName", m.ExtraProperties["resourceGroup"])
+        };
+    }
+}

--- a/Modules/BenchPress.Azure/BenchPress.Azure.psd1
+++ b/Modules/BenchPress.Azure/BenchPress.Azure.psd1
@@ -39,6 +39,7 @@
     "Confirm-KeyVaultKey",
     "Confirm-KeyVaultSecret",
     "Confirm-OperationalInsightsWorkspace",
+    "Confirm-PortalDashboard",
     "Confirm-Resource",
     "Confirm-ResourceGroup",
     "Confirm-RoleAssignment",

--- a/Modules/BenchPress.Azure/Classes/ResourceType.psm1
+++ b/Modules/BenchPress.Azure/Classes/ResourceType.psm1
@@ -23,6 +23,7 @@
   EventHubNamespace
   KeyVault
   OperationalInsightsWorkspace
+  PortalDashboard
   ResourceGroup
   RoleAssignment
   SqlDatabase

--- a/Modules/BenchPress.Azure/Public/Confirm-PortalDashboard.ps1
+++ b/Modules/BenchPress.Azure/Public/Confirm-PortalDashboard.ps1
@@ -1,0 +1,48 @@
+﻿# INLINE_SKIP
+using module ./../Classes/ConfirmResult.psm1
+
+. $PSScriptRoot/../Private/Connect-Account.ps1
+# end INLINE_SKIP
+
+function Confirm-PortalDashboard {
+  <#
+    .SYNOPSIS
+      Confirms that an Azure Dashboard exists.
+
+    .DESCRIPTION
+      The Confirm-AzBPPortalDashboard cmdlet gets an Azure Dashboard using the specified Dashboard and Resource Group names.
+
+    .PARAMETER Name
+      The name of the Azure Dashboard.
+
+    .PARAMETER ResourceGroupName
+      The name of the Resource Group. The name is case insensitive.
+
+    .EXAMPLE
+      Confirm-AzBPPortalDashboard -Name "benchpresstest" -ResourceGroupName "rgbenchpresstest"
+
+    .INPUTS
+      System.String
+
+    .OUTPUTS
+      ConfirmResult
+  #>
+  [CmdletBinding()]
+  [OutputType([ConfirmResult])]
+  param (
+    [Parameter(Mandatory=$true)]
+    [string]$Name,
+
+    [Parameter(Mandatory=$true)]
+    [string]$ResourceGroupName
+  )
+  Begin {
+    $connectResults = Connect-Account
+  }
+  Process {
+    $resource = Get-AzPortalDashboard -ResourceGroupName $ResourceGroupName -Name $Name
+
+    [ConfirmResult]::new($resource, $connectResults.AuthenticationData)
+  }
+  End { }
+}

--- a/Modules/BenchPress.Azure/Public/Get-ResourceByType.ps1
+++ b/Modules/BenchPress.Azure/Public/Get-ResourceByType.ps1
@@ -16,6 +16,7 @@ using module ./../Classes/ResourceType.psm1
 . $PSScriptRoot/Confirm-EventHubNamespace.ps1
 . $PSScriptRoot/Confirm-KeyVault.ps1
 . $PSScriptRoot/Confirm-OperationalInsightsWorkspace.ps1
+. $PSScriptRoot/Confirm-PortalDashboard.ps1
 . $PSScriptRoot/Confirm-ResourceGroup.ps1
 . $PSScriptRoot/Confirm-SqlDatabase.ps1
 . $PSScriptRoot/Confirm-SqlServer.ps1
@@ -283,6 +284,9 @@ function Get-ResourceByType {
       }
       "OperationalInsightsWorkspace" {
         return Confirm-OperationalInsightsWorkspace -Name $ResourceName -ResourceGroupName $ResourceGroupName
+      }
+      "PortalDashboard" {
+        return Confirm-PortalDashboard -ResourceGroupName $ResourceGroupName -Name $ResourceName
       }
       "ResourceGroup" {
         return Confirm-ResourceGroup -ResourceGroupName $ResourceName

--- a/Modules/BenchPress.Azure/Tests/Public/Confirm-PortalDashboard.Tests.ps1
+++ b/Modules/BenchPress.Azure/Tests/Public/Confirm-PortalDashboard.Tests.ps1
@@ -1,0 +1,23 @@
+﻿BeforeAll {
+  . $PSScriptRoot/../../Public/Confirm-PortalDashboard.ps1
+  . $PSScriptRoot/../../Private/Connect-Account.ps1
+  Import-Module Az
+}
+
+Describe "Confirm-PortalDashboard" {
+  Context "unit tests" -Tag "Unit" {
+    BeforeEach {
+      Mock Connect-Account{}
+      Mock Get-AzPortalDashboard{}
+    }
+
+    It "Calls Get-AzPortalDashboard" {
+      Confirm-PortalDashboard -Name "dashboard" -ResourceGroupName "rgn"
+      Should -Invoke -CommandName "Get-AzPortalDashboard" -Times 1
+    }
+  }
+}
+
+AfterAll {
+  Remove-Module Az
+}

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -21,6 +21,9 @@ as their testing framework and runner. To use BenchPress, have the following ins
   - [Az.App PowerShell module](https://learn.microsoft.com/en-us/powershell/module/az.app/?view=azps-9.5.0) for any
     testing of Container Applications. Az.App is not GA yet which is why it is not included with the main Az
     PowerShell module.
+  - [Az.Portal PowerShell module](https://learn.microsoft.com/en-us/powershell/module/az.app/?view=azps-9.5.0) for any
+    testing of Azure Dashboards. Az.Portal is not GA yet which is why it is not included with the main Az
+    PowerShell module.
 - [Pester](https://pester.dev/docs/introduction/installation)
 - [Bicep](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/install#azure-powershell)
 - [Service Principal](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal)

--- a/examples/Dashboard/Dashboard.Tests.ps1
+++ b/examples/Dashboard/Dashboard.Tests.ps1
@@ -1,0 +1,66 @@
+﻿BeforeAll {
+  Import-Module Az.InfrastructureTesting
+
+  $Script:rgName   = 'rg-test'
+  $Script:location = 'westus3'
+  $Script:dashboardName = 'sampleDashboard'
+}
+
+Describe 'Verify Dashboard' {
+  BeforeAll {
+    $Script:noDashboardName = 'noDashboard'
+  }
+
+  It "Should contain a Dashboard named $dashboardName - Confirm-AzBPResource" {
+    # arrange
+    $params = @{
+      ResourceType      = "PortalDashboard"
+      ResourceName      = $dashboardName
+      ResourceGroupName = $rgName
+    }
+
+    # act and assert
+    Confirm-AzBPResource @params | Should -BeSuccessful
+  }
+
+  It "Should contain a Dashboard named $dashboardName - Confirm-AzBPResource" {
+    # arrange
+    $params = @{
+      ResourceType      = "PortalDashboard"
+      ResourceName      = $dashboardName
+      ResourceGroupName = $rgName
+      PropertyKey       = "Name"
+      PropertyValue     = $dashboardName
+    }
+
+    # act and assert
+    Confirm-AzBPResource @params | Should -BeSuccessful
+  }
+
+  It "Should contain a Dashboard named $dashboardName" {
+    Confirm-AzBPPortalDashboard -ResourceGroupName $rgName -Name $dashboardName | Should -BeSuccessful
+  }
+
+  It "Should not contain a Dashboard named $noDashboardName" {
+    # arrange
+    # The '-ErrorAction SilentlyContinue' command suppresses all errors.
+    # In this test, it will suppress the error message when a resource cannot be found.
+    # Remove this field to see all errors.
+    $params = @{
+      ResourceGroupName = $rgName
+      Name              = $noDashboardName
+      ErrorAction       = 'SilentlyContinue'
+    }
+
+    # act and assert
+    Confirm-AzBPPortalDashboard @params | Should -Not -BeSuccessful
+  }
+
+  It "Should contain a Dashboard named $dashboardName in $location" {
+    Confirm-AzBPPortalDashboard -ResourceGroupName $rgName -Name $dashboardName | Should -BeInLocation $location
+  }
+
+  It "Should contain a Dashboard named $dashboardName in $rgName" {
+    Confirm-AzBPPortalDashboard -ResourceGroupName $rgName -Name $dashboardName | Should -BeInResourceGroup $rgName
+  }
+}

--- a/examples/Dashboard/Dashboard.Tests.ps1
+++ b/examples/Dashboard/Dashboard.Tests.ps1
@@ -7,10 +7,6 @@
 }
 
 Describe 'Verify Dashboard' {
-  BeforeAll {
-    $Script:noDashboardName = 'noDashboard'
-  }
-
   It "Should contain a Dashboard named $dashboardName - Confirm-AzBPResource" {
     # arrange
     $params = @{
@@ -39,21 +35,6 @@ Describe 'Verify Dashboard' {
 
   It "Should contain a Dashboard named $dashboardName" {
     Confirm-AzBPPortalDashboard -ResourceGroupName $rgName -Name $dashboardName | Should -BeSuccessful
-  }
-
-  It "Should not contain a Dashboard named $noDashboardName" {
-    # arrange
-    # The '-ErrorAction SilentlyContinue' command suppresses all errors.
-    # In this test, it will suppress the error message when a resource cannot be found.
-    # Remove this field to see all errors.
-    $params = @{
-      ResourceGroupName = $rgName
-      Name              = $noDashboardName
-      ErrorAction       = 'SilentlyContinue'
-    }
-
-    # act and assert
-    Confirm-AzBPPortalDashboard @params | Should -Not -BeSuccessful
   }
 
   It "Should contain a Dashboard named $dashboardName in $location" {

--- a/examples/Dashboard/Dashboard_Example.md
+++ b/examples/Dashboard/Dashboard_Example.md
@@ -1,0 +1,47 @@
+# How To Run Dashboard.Tests.ps1
+
+`Dashboard.Tests.ps1` contains examples of using the `Confirm-AzBPPortalDashboard` cmdlet.
+
+## Pre-Requisites
+
+- Follow the [setup instructions](../README.md)
+
+## Steps
+
+1. Navigate to Dashboard directory:
+
+   ```Powershell
+   cd examples\Dashboard\
+   ```
+
+1. Deploy the Azure Dashboard to your resource group:
+
+   ```Powershell
+    New-AzResourceGroupDeployment -ResourceGroupName "<your-resource-group-name>"`
+    -TemplateFile ".\dashboard.bicep"
+   ```
+
+1. Update `Dashboard.Tests.ps1` variables to point to your expected resources:
+
+   - `rg-test`         -> `your-resource-group-name`
+   - `sampleDashboard` -> `your-dashboard-name`
+   - `westus3`         -> `your-dashboard-location`
+
+1. If using a local copy of `Az.InfrastructureTesting`, replace `Import-Module Az.InfrastructureTesting` with
+`Import-Module "../../bin/BenchPress.Azure.psd1"`. Note that the final `AfterAll` step will properly remove the module
+regardless of which method is chosen to load the module.
+
+1. Run `Dashboard.Tests.ps1`:
+
+   ```Powershell
+   Invoke-Pester -Path .\Dashboard.Tests.ps1
+   ```
+
+1. Success!
+
+   ```Powershell
+    Tests completed in 2.25s
+    Tests Passed: 6, Failed: 0, Skipped: 0 NotRun: 0
+   ```
+
+1. Don't forget to delete any deployed resources that are no longer needed.

--- a/examples/Dashboard/dashboard.bicep
+++ b/examples/Dashboard/dashboard.bicep
@@ -1,0 +1,38 @@
+param dashboardName string = 'dash${take(uniqueString(resourceGroup().id), 5)}'
+param dashboardDisplayName string = 'Sample Dashboard'
+param location string = resourceGroup().location
+
+resource dashboard 'Microsoft.Portal/dashboards@2020-09-01-preview' = {
+  name: dashboardName
+  location: location
+  tags: {
+    'hidden-title': dashboardDisplayName
+  }
+  properties: {
+    lenses: [
+      {
+        order: 0
+        parts: [
+          {
+            position: {
+              x: 0
+              y: 0
+              colSpan: 4
+              rowSpan: 6
+            }
+            metadata: {
+              inputs: []
+              type: 'Extension/HubsExtension/PartType/MarkdownPart'
+              settings: {
+                content: {
+                  settings: {
+                    content: '## Test Dashboard\r\nThis is a test dashboard.'
+                  }
+                }
+              }
+            }
+          }
+        ]
+    }]
+  }
+}


### PR DESCRIPTION
Closes #260.

Note, Az.Portal module needs to be separately installed because it is not a part of the main Az Module. Following up with PG here: https://github.com/Azure/azure-powershell/issues/21363. Follow up issue to remove Az.Portal when it becomes GA: https://github.com/Azure/benchpress/issues/287.

Also note, the negative test throws an exception, so it has not been included as an example test.