### PR TITLE
Test all resources in  Get-ResourceByType unit tests

### DIFF
--- a/Modules/BenchPress.Azure/Tests/Public/Get-ResourceByType.Tests.ps1
+++ b/Modules/BenchPress.Azure/Tests/Public/Get-ResourceByType.Tests.ps1
@@ -3,13 +3,13 @@
 BeforeDiscovery {
   $testCases = @()
 
-  foreach ($i in [ResourceType].GetEnumNames())
+  foreach ($resourceType in [ResourceType].GetEnumNames())
   {
-    $functionName = "Confirm-$i"
+    $functionName = "Confirm-$resourceType"
 
     # build test case array
     $testObject = @{
-      ResourceType = $i
+      ResourceType = $resourceType
       Expected = $functionName
     }
 
@@ -20,9 +20,9 @@ BeforeDiscovery {
 BeforeAll {
   . $PSScriptRoot/../../Public/Get-ResourceByType.ps1
 
-  foreach ($i in [ResourceType].GetEnumNames())
+  foreach ($resourceType in [ResourceType].GetEnumNames())
   {
-    $functionName = "Confirm-$i"
+    $functionName = "Confirm-$resourceType"
     $fileName = "$functionName.ps1"
 
     # dot-source the powershell function

--- a/Modules/BenchPress.Azure/Tests/Public/Get-ResourceByType.Tests.ps1
+++ b/Modules/BenchPress.Azure/Tests/Public/Get-ResourceByType.Tests.ps1
@@ -49,6 +49,9 @@ Describe "Get-ResourceByType" {
         ServiceName = 'servicename'
         ClusterName = 'clustername'
         JobName = 'jobname'
+        KeyVaultName = "keyvaultname"
+        RoleAssignmentId = 'roleassignmentid'
+        RoleDefinitionId = 'roledefinitionid'
       }
 
       $functionName = "Confirm-$ResourceType"

--- a/Modules/BenchPress.Azure/Tests/Public/Get-ResourceByType.Tests.ps1
+++ b/Modules/BenchPress.Azure/Tests/Public/Get-ResourceByType.Tests.ps1
@@ -1,34 +1,56 @@
-﻿BeforeAll {
-  . $PSScriptRoot/../../Public/Confirm-AppServicePlan.ps1
-  . $PSScriptRoot/../../Public/Confirm-ResourceGroup.ps1
-  . $PSScriptRoot/../../Public/Confirm-SqlDatabase.ps1
-  . $PSScriptRoot/../../Public/Confirm-SqlServer.ps1
-  . $PSScriptRoot/../../Public/Confirm-VirtualMachine.ps1
-  . $PSScriptRoot/../../Public/Confirm-WebApp.ps1
+﻿using module ./../../Classes/ResourceType.psm1
+
+BeforeAll {
   . $PSScriptRoot/../../Public/Get-ResourceByType.ps1
+  $testCases = @()
+
+  foreach ($i in [ResourceType].GetEnumNames())
+  {
+    $functionName = "Confirm-$i"
+    $fileName = "$functionName.ps1"
+
+    # dot-source the powershell function
+    . $PSScriptRoot/../../Public/$fileName
+
+    # build test case array
+    $testObject = @{
+      ResourceType = $resource
+      Expected = $functionName
+    }
+
+    $testCases+=$testObject
+  }
 }
 
 Describe "Get-ResourceByType" {
   Context "unit tests" -Tag "Unit" {
     BeforeEach {
-      Mock Confirm-ResourceGroup{}
-      Mock Confirm-AppServicePlan{}
-      Mock Confirm-SqlDatabase{}
-      Mock Confirm-SqlServer{}
-      Mock Confirm-VirtualMachine{}
-      Mock Confirm-WebApp{}
+      foreach ($i in [ResourceType].GetEnumNames())
+      {
+        $functionName = "Confirm-$i"
+        Mock $functionName {}
+      }
     }
 
-    It "Calls <expected> when <resourceType> is used" -TestCases @(
-      @{ ResourceType = "ResourceGroup"; Expected = "Confirm-ResourceGroup"}
-      @{ ResourceType = "AppServicePlan"; Expected = "Confirm-AppServicePlan"}
-      @{ ResourceType = "SqlDatabase"; Expected = "Confirm-SqlDatabase"}
-      @{ ResourceType = "SqlServer"; Expected = "Confirm-SqlServer"}
-      @{ ResourceType = "VirtualMachine"; Expected = "Confirm-VirtualMachine"}
-      @{ ResourceType = "WebApp"; Expected = "Confirm-WebApp"}
-    ) {
-      Get-ResourceByType -ResourceName resource -ResourceGroupName group -ResourceType $ResourceType -ServerName server
-      Should -Invoke -CommandName $Expected -Times 1
+    It "Calls <expected> when <resourceType> is used" -TestCases $testCases {
+      $params = @{
+        ResourceName = 'resourcename'
+        ResourceGroupName = 'resourcegroupname'
+        ResourceType = $ResourceType
+        ServerName = 'servername'
+        DataFactoryName = 'datafactoryname'
+        NamespaceName = 'namespacename'
+        EventHubName = 'eventhubname'
+        WorkspaceName = 'workspacename'
+        AccountName = 'accountname'
+        ServicePrincipalId = 'serviceprincipalid'
+        Scope = '/subscriptions/'
+        RoleDefinitionName = 'roledefinitionname'
+        ServiceName = 'servicename'
+        ClusterName = 'clustername'
+        JobName = 'jobname'
+      }
+      Get-ResourceByType @params | Should -Invoke -CommandName $Expected -Times 1
     }
   }
 }

--- a/Modules/BenchPress.Azure/Tests/Public/Get-ResourceByType.Tests.ps1
+++ b/Modules/BenchPress.Azure/Tests/Public/Get-ResourceByType.Tests.ps1
@@ -1,8 +1,24 @@
 ﻿using module ./../../Classes/ResourceType.psm1
 
+BeforeDiscovery {
+  $testCases = @()
+
+  foreach ($i in [ResourceType].GetEnumNames())
+  {
+    $functionName = "Confirm-$i"
+
+    # build test case array
+    $testObject = @{
+      ResourceType = $i
+      Expected = $functionName
+    }
+
+    $testCases+=$testObject
+  }
+}
+
 BeforeAll {
   . $PSScriptRoot/../../Public/Get-ResourceByType.ps1
-  $testCases = @()
 
   foreach ($i in [ResourceType].GetEnumNames())
   {
@@ -11,26 +27,19 @@ BeforeAll {
 
     # dot-source the powershell function
     . $PSScriptRoot/../../Public/$fileName
-
-    # build test case array
-    $testObject = @{
-      ResourceType = $resource
-      Expected = $functionName
-    }
-
-    $testCases+=$testObject
   }
 }
 
 Describe "Get-ResourceByType" {
-  Context "unit tests" -Tag "Unit" {
-    BeforeEach {
-      foreach ($i in [ResourceType].GetEnumNames())
-      {
-        $functionName = "Confirm-$i"
-        Mock $functionName {}
-      }
+  BeforeAll {
+    foreach ($i in [ResourceType].GetEnumNames())
+    {
+      $functionName = "Confirm-$i"
+      Mock $functionName {}
     }
+  }
+
+  Context "unit tests" -Tag "Unit" {
 
     It "Calls <expected> when <resourceType> is used" -TestCases $testCases {
       $params = @{


### PR DESCRIPTION
Closes #302

**Note:** This is in draft mode since I'm not sure if this is the approach we want to take.

- Iterate through the `ResourceType` enum and use it to determine the Powershell function name
- Dynamically determine test cases based on the `ResourceType` enum
- Add new `Get-ResourceByType` parameters to test