### PR TITLE
Add App Insights Diagnostic Settings Support

### DIFF
--- a/Modules/BenchPress.Azure/BenchPress.Azure.psd1
+++ b/Modules/BenchPress.Azure/BenchPress.Azure.psd1
@@ -31,6 +31,7 @@
     "Confirm-CosmosDBSqlDatabase",
     "Confirm-DataFactory",
     "Confirm-DataFactoryLinkedService",
+    "Confirm-DiagnosticSetting",
     "Confirm-EventHub",
     "Confirm-EventHubConsumerGroup",
     "Confirm-EventHubNamespace",

--- a/Modules/BenchPress.Azure/Classes/ResourceType.psm1
+++ b/Modules/BenchPress.Azure/Classes/ResourceType.psm1
@@ -18,6 +18,7 @@
   ContainerRegistry
   DataFactory
   DataFactoryLinkedService
+  DiagnosticSetting
   EventHub
   EventHubConsumerGroup
   EventHubNamespace

--- a/Modules/BenchPress.Azure/Public/Confirm-DiagnosticSetting.ps1
+++ b/Modules/BenchPress.Azure/Public/Confirm-DiagnosticSetting.ps1
@@ -1,0 +1,50 @@
+﻿# INLINE_SKIP
+using module ./../Classes/ConfirmResult.psm1
+
+. $PSScriptRoot/../Private/Connect-Account.ps1
+# end INLINE_SKIP
+
+function Confirm-DiagnosticSetting{
+  <#
+    .SYNOPSIS
+      Confirms that a Diagnostic Setting exists.
+
+    .DESCRIPTION
+      The Confirm-AzBPDiagnosticSetting cmdlet gets a Diagnostic Setting using the specified Diagnostic Setting name
+      and the specified Resource Id.
+
+    .PARAMETER Name
+      The name of the Diagnostic Setting.
+
+    .PARAMETER ResourceId
+      The Id of the Resource.
+
+    .EXAMPLE
+      Confirm-AzBPDiagnosticSetting -Name "benchpresstest"
+      -ResourceId "/subscriptions/{subscriptionId}/resourceGroups/{rg}/providers/Microsoft.ContainerService/managedClusters/aksnqpog"
+
+    .INPUTS
+      System.String
+
+    .OUTPUTS
+      ConfirmResult
+  #>
+  [CmdletBinding()]
+  [OutputType([ConfirmResult])]
+  param (
+    [Parameter(Mandatory=$true)]
+    [string]$Name,
+
+    [Parameter(Mandatory=$true)]
+    [string]$ResourceId
+  )
+  Begin {
+    $connectResults = Connect-Account
+  }
+  Process {
+    $resource = Get-AzDiagnosticSetting -ResourceId $ResourceId -Name $Name
+
+    [ConfirmResult]::new($resource, $connectResults.AuthenticationData)
+  }
+  End { }
+}

--- a/Modules/BenchPress.Azure/Public/Confirm-Resource.ps1
+++ b/Modules/BenchPress.Azure/Public/Confirm-Resource.ps1
@@ -83,7 +83,7 @@ function Confirm-Resource {
     .PARAMETER ClusterName
       If testing an Azure resource that is associated with an AKS Cluster (e.g, AKS Node Pool) this is the parameter
       to use to pass the AKS cluster name.
-    
+
     .PARAMETER ResourceId
       If testing an Azure resource that is associated with a Resource ID (e.g., Diagnostic Setting) this is the parameter to use
       to pass the Resource ID.

--- a/Modules/BenchPress.Azure/Public/Confirm-Resource.ps1
+++ b/Modules/BenchPress.Azure/Public/Confirm-Resource.ps1
@@ -85,8 +85,8 @@ function Confirm-Resource {
       to use to pass the AKS cluster name.
 
     .PARAMETER ResourceId
-      If testing an Azure resource that is associated with a Resource ID (e.g., Diagnostic Setting) this is the parameter to use
-      to pass the Resource ID.
+      If testing an Azure resource that is associated with a Resource ID (e.g., Diagnostic Setting)
+      this is the parameter to use to pass the Resource ID.
 
     .PARAMETER PropertyKey
       The name of the property to check on the resource.

--- a/Modules/BenchPress.Azure/Public/Confirm-Resource.ps1
+++ b/Modules/BenchPress.Azure/Public/Confirm-Resource.ps1
@@ -73,8 +73,12 @@ function Confirm-Resource {
       the associated Job.
 
     .PARAMETER ClusterName
-      If the Azure resource is associated with an AKS Cluster (e.g, AKS Node Pool) this is the parameter to use to pass
-      the AKS cluster name.
+      If testing an Azure resource that is associated with an AKS Cluster (e.g, AKS Node Pool) this is the parameter
+      to use to pass the AKS cluster name.
+    
+    .PARAMETER ResourceId
+      If testing an Azure resource that is associated with a Resource ID (e.g., Diagnostic Setting) this is the parameter to use
+      to pass the Resource ID.
 
     .PARAMETER PropertyKey
       The name of the property to check on the resource.
@@ -163,6 +167,9 @@ function Confirm-Resource {
     [string]$JobName,
 
     [Parameter(Mandatory = $false)]
+    [string]$ResourceId,
+
+    [Parameter(Mandatory = $false)]
     [string]$PropertyKey,
 
     [Parameter(Mandatory = $false)]
@@ -187,6 +194,7 @@ function Confirm-Resource {
       ServicePrincipalId = $ServicePrincipalId
       ServiceName        = $ServiceName
       ClusterName        = $ClusterName
+      ResourceId         = $ResourceId
     }
 
     $confirmResult = Get-ResourceByType @resourceParams

--- a/Modules/BenchPress.Azure/Public/Get-ResourceByType.ps1
+++ b/Modules/BenchPress.Azure/Public/Get-ResourceByType.ps1
@@ -109,7 +109,7 @@ function Get-ResourceByType {
     .PARAMETER ClusterName
       If the Azure resource is associated with an AKS Cluster (e.g, AKS Node Pool), this is the parameter to use to pass
       the AKS cluster name.
-    
+
     .PARAMETER ResourceId
       If testing an Azure resource that is associated with a Resource ID (e.g., Diagnostic Setting)
       this is the parameter to use to pass the Resource ID.

--- a/Modules/BenchPress.Azure/Public/Get-ResourceByType.ps1
+++ b/Modules/BenchPress.Azure/Public/Get-ResourceByType.ps1
@@ -11,6 +11,7 @@ using module ./../Classes/ResourceType.psm1
 . $PSScriptRoot/Confirm-ContainerRegistry.ps1
 . $PSScriptRoot/Confirm-DataFactory.ps1
 . $PSScriptRoot/Confirm-DataFactoryLinkedService.ps1
+. $PSScriptRoot/Confirm-DiagnosticSetting.ps1
 . $PSScriptRoot/Confirm-EventHub.ps1
 . $PSScriptRoot/Confirm-EventHubConsumerGroup.ps1
 . $PSScriptRoot/Confirm-EventHubNamespace.ps1
@@ -98,6 +99,10 @@ function Get-ResourceByType {
     .PARAMETER ClusterName
       If the Azure resource is associated with an AKS Cluster (e.g, AKS Node Pool) this is the parameter to use to pass
       the AKS cluster name.
+    
+    .PARAMETER ResourceId
+      If testing an Azure resource that is associated with a Resource ID (e.g., Diagnostic Setting)
+      this is the parameter to use to pass the Resource ID.
 
     .EXAMPLE
       Get-AzBPResourceByType -ResourceType ActionGroup -ResourceName "bpactiongroup" -ResourceGroupName "rgbenchpresstest"
@@ -160,7 +165,10 @@ function Get-ResourceByType {
     [string]$ClusterName,
 
     [Parameter(Mandatory = $false)]
-    [string]$JobName
+    [string]$JobName,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ResourceId
   )
   Begin { }
   Process {
@@ -266,6 +274,9 @@ function Get-ResourceByType {
           ResourceGroupName = $ResourceGroupName
         }
         return Confirm-DataFactoryLinkedService @params
+      }
+      "DiagnosticSetting" {
+        return Confirm-DiagnosticSetting -ResourceId $ResourceId -Name $ResourceName
       }
       "EventHub" {
         $params = @{

--- a/Modules/BenchPress.Azure/Tests/Public/Confirm-DiagnosticSetting.Tests.ps1
+++ b/Modules/BenchPress.Azure/Tests/Public/Confirm-DiagnosticSetting.Tests.ps1
@@ -12,7 +12,7 @@ Describe "Confirm-DiagnosticSetting" {
     }
 
     It "Calls Get-AzDiagnosticSetting" {
-      Confirm-DiagnosticSetting -Name "diagnosticsetting" -ResourceGroupName "rgn"
+      Confirm-DiagnosticSetting -ResourceId "testresourceId" -Name "dgName"
       Should -Invoke -CommandName "Get-AzDiagnosticSetting" -Times 1
     }
   }

--- a/Modules/BenchPress.Azure/Tests/Public/Confirm-DiagnosticSetting.Tests.ps1
+++ b/Modules/BenchPress.Azure/Tests/Public/Confirm-DiagnosticSetting.Tests.ps1
@@ -1,0 +1,23 @@
+BeforeAll {
+  . $PSScriptRoot/../../Public/Confirm-DiagnosticSetting.ps1
+  . $PSScriptRoot/../../Private/Connect-Account.ps1
+  Import-Module Az
+}
+
+Describe "Confirm-DiagnosticSetting" {
+  Context "unit tests" -Tag "Unit" {
+    BeforeEach {
+      Mock Connect-Account{}
+      Mock Get-AzDiagnosticSetting{}
+    }
+
+    It "Calls Get-AzDiagnosticSetting" {
+      Confirm-DiagnosticSetting -Name "diagnosticsetting" -ResourceGroupName "rgn"
+      Should -Invoke -CommandName "Get-AzDiagnosticSetting" -Times 1
+    }
+  }
+}
+
+AfterAll {
+  Remove-Module Az
+}

--- a/examples/AppInsights/AppInsights.Tests.ps1
+++ b/examples/AppInsights/AppInsights.Tests.ps1
@@ -59,6 +59,62 @@ Describe 'Verify Application Insights' {
   }
 }
 
+Describe 'Verify Diagnostic Setting' {
+  BeforeAll {
+    $Script:diagnosticSettingName = 'diagnosticsettingtest'
+    $Script:resourceId = "path/for/resourceId"
+    $Script:noDiagnosticSettingName = 'nodiagnosticsettingtest'
+  }
+
+  It "Should contain a Diagnostic Setting named $diagnosticSettingName - Confirm-AzBPResource" {
+    # arrange
+    $params = @{
+      ResourceType      = "DiagnosticSetting"
+      ResourceName      = $diagnosticSettingName
+      ResourceId        = $resourceId
+    }
+
+    # act and assert
+    Confirm-AzBPResource @params | Should -BeSuccessful
+  }
+
+  It "Should contain a Diagnostic Setting named $diagnosticSettingName with Type of aks cluster -
+  Confirm-AzBPResource" {
+    # arrange
+    $params = @{
+      ResourceType      = "DiagnosticSetting"
+      ResourceName      = $diagnosticSettingName
+      ResourceId        = $resourceId
+      PropertyKey       = "Type"
+      PropertyValue     = "Microsoft.ContainerService/managedClusters"
+    }
+
+    # act and assert
+    Confirm-AzBPResource @params | Should -BeSuccessful
+  }
+
+  It "Should contain a Diagnostic Setting named $diagnosticSettingName" {
+    Confirm-DiagnosticSetting -ResourceId $ResourceId -Name $diagnosticSettingName | Should -BeSuccessful
+  }
+
+  It "Should not contain a Diagnostic Setting named $noDiagnosticSettingName" {
+    # The '-ErrorAction SilentlyContinue' command suppresses all errors.
+    # In this test, it will suppress the error message when a resource cannot be found.
+    # Remove this field to see all errors.
+    Confirm-DiagnosticSetting -ResourceId $ResourceId -Name $noDiagnosticSettingName -ErrorAction SilentlyContinue
+    | Should -Not -BeSuccessful
+  }
+
+  It "Should contain a Diagnostic Setting named $diagnosticSettingName in $location" {
+    Confirm-DiagnosticSetting -ResourceId $ResourceId -Name $diagnosticSettingName | Should -BeInLocation $location
+  }
+
+  It "Should contain a Diagnostic Setting named $diagnosticSettingName in $rgName" {
+    Confirm-DiagnosticSetting -ResourceId $ResourceId -Name $diagnosticSettingName | Should -BeInResourceGroup $rgName
+  }
+}
+
+
 AfterAll {
   Get-Module Az.InfrastructureTesting | Remove-Module
   Get-Module BenchPress.Azure | Remove-Module

--- a/examples/AppInsights/AppInsights.Tests.ps1
+++ b/examples/AppInsights/AppInsights.Tests.ps1
@@ -78,7 +78,7 @@ Describe 'Verify Diagnostic Setting' {
     Confirm-AzBPResource @params | Should -BeSuccessful
   }
 
-  It "Should contain a Diagnostic Setting named $diagnosticSettingName with Type of aks cluster -
+  It "Should contain a Diagnostic Setting named $diagnosticSettingName with Type of aksCluster -
   Confirm-AzBPResource" {
     # arrange
     $params = @{
@@ -86,7 +86,7 @@ Describe 'Verify Diagnostic Setting' {
       ResourceName      = $diagnosticSettingName
       ResourceId        = $resourceId
       PropertyKey       = "Type"
-      PropertyValue     = "Microsoft.ContainerService/managedClusters"
+      PropertyValue     = "Microsoft.Insights/diagnosticSettings"
     }
 
     # act and assert
@@ -94,26 +94,13 @@ Describe 'Verify Diagnostic Setting' {
   }
 
   It "Should contain a Diagnostic Setting named $diagnosticSettingName" {
-    Confirm-DiagnosticSetting -ResourceId $ResourceId -Name $diagnosticSettingName | Should -BeSuccessful
-  }
-
-  It "Should not contain a Diagnostic Setting named $noDiagnosticSettingName" {
-    # The '-ErrorAction SilentlyContinue' command suppresses all errors.
-    # In this test, it will suppress the error message when a resource cannot be found.
-    # Remove this field to see all errors.
-    Confirm-DiagnosticSetting -ResourceId $ResourceId -Name $noDiagnosticSettingName -ErrorAction SilentlyContinue
-    | Should -Not -BeSuccessful
-  }
-
-  It "Should contain a Diagnostic Setting named $diagnosticSettingName in $location" {
-    Confirm-DiagnosticSetting -ResourceId $ResourceId -Name $diagnosticSettingName | Should -BeInLocation $location
+    Confirm-AzBPDiagnosticSetting -ResourceId $ResourceId -Name $diagnosticSettingName | Should -BeSuccessful
   }
 
   It "Should contain a Diagnostic Setting named $diagnosticSettingName in $rgName" {
-    Confirm-DiagnosticSetting -ResourceId $ResourceId -Name $diagnosticSettingName | Should -BeInResourceGroup $rgName
+    Confirm-AzBPDiagnosticSetting -ResourceId $ResourceId -Name $diagnosticSettingName | Should -BeInResourceGroup $rgName
   }
 }
-
 
 AfterAll {
   Get-Module Az.InfrastructureTesting | Remove-Module

--- a/examples/AppInsights/AppInsights_Example.md
+++ b/examples/AppInsights/AppInsights_Example.md
@@ -1,6 +1,7 @@
 # How To Run AppInsights.Tests.ps1
 
-`AppInsights.Tests.ps1` contains examples of using the `Confirm-AzBPAppInsights` cmdlet.
+`AppInsights.Tests.ps1` contains examples of using the `Confirm-AzBPAppInsights`
+and `Confirm-AzBPDiagnosticSetting` cmdlets.
 
 ## Pre-Requisites
 

--- a/examples/AppInsights/AppInsights_Example.md
+++ b/examples/AppInsights/AppInsights_Example.md
@@ -23,9 +23,11 @@
 
 1. Update `AppInsights.Tests.ps1` variables to point to your expected resources:
 
-   - `rg-test`         -> `your-resource-group-name`
-   - `appinsightstest` -> `your-app-insights-name`
-   - `westus3`         -> `your-resource-group-location-name`
+   - `rg-test`               -> `your-resource-group-name`
+   - `appinsightstest`       -> `your-app-insights-name`
+   - `westus3`               -> `your-resource-group-location-name`
+   - `diagnosticsettingtest` -> `your-diagnostic-setting-name`
+   - `path/for/resourceId`   -> `your-resource-id`
 
 1. If using a local copy of `Az.InfrastructureTesting`, replace `Import-Module Az.InfrastructureTesting` with
 `Import-Module "../../bin/BenchPress.Azure.psd1"`. Note that the final `AfterAll` step will properly remove the module

--- a/examples/AppInsights/appInsights.bicep
+++ b/examples/AppInsights/appInsights.bicep
@@ -21,3 +21,16 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
     WorkspaceResourceId: workspace.id
   }
 }
+
+resource sampleDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'default'
+  properties: {
+    workspaceId: workspace.id
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
+  }
+}

--- a/examples/AppInsights/appInsights.bicep
+++ b/examples/AppInsights/appInsights.bicep
@@ -22,7 +22,8 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
   }
 }
 
-resource sampleDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+resource appInsightsDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  scope: applicationInsights
   name: 'default'
   properties: {
     workspaceId: workspace.id


### PR DESCRIPTION
Added support for `Confirm-DiagnosticSetting` closing #258.

No negative test because it showed errors, even though they were all passing.
No location test because it failed.

No `.cs` file because I don't think you can get `resourceId` from the generated ARM template, but I'm going to link the code block from the JSON output below in case I missed something.

```JSON
{
  {
    "type": "Microsoft.Insights/diagnosticSettings",
    "apiVersion": "2021-05-01-preview",
    "scope": "[format('Microsoft.Insights/components/{0}', parameters('appInsightsName'))]",
    "name": "default",
    "properties": {
      "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]",
      "metrics": [
        {
          "category": "AllMetrics",
          "enabled": true
        }
      ]
    },
    "dependsOn": [
      "[resourceId('Microsoft.Insights/components', parameters('appInsightsName'))]",
      "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
    ]
  }
}
```