### PR TITLE
Generate `-BeSuccessful` Tests

### DIFF
--- a/BenchPress/Generators/LanguageProviders/ILanguageProvider.cs
+++ b/BenchPress/Generators/LanguageProviders/ILanguageProvider.cs
@@ -8,6 +8,7 @@ public interface ILanguageProvider
     public string Escape(string value);
     public string Variable(string name);
     public string Value(object value);
+    public string AssertionDetails(TestType testType);
     public string Library(ResourceType resourceType);
     public string SDK(SDKFunction sdkFunction);
     public string Parameter(string name);

--- a/BenchPress/Generators/LanguageProviders/ILanguageProvider.cs
+++ b/BenchPress/Generators/LanguageProviders/ILanguageProvider.cs
@@ -4,14 +4,11 @@ namespace Generators.LanguageProviders;
 
 public interface ILanguageProvider
 {
-    public string Function(string name);
     public string Escape(string value);
-    public string Variable(string name);
     public string Value(object value);
     public string AssertionDetails(TestType testType);
     public string Library(ResourceType resourceType);
     public string SDK(SDKFunction sdkFunction);
     public string Parameter(string name);
-    public string ParameterList(params string[] parameters);
     public string GetTemplateFileName();
 }

--- a/BenchPress/Generators/LanguageProviders/PowershellLanguageProvider.cs
+++ b/BenchPress/Generators/LanguageProviders/PowershellLanguageProvider.cs
@@ -9,11 +9,6 @@ public class PowershellLanguageProvider : ILanguageProvider
         return name;
     }
 
-    public string Variable(string name)
-    {
-        return $"${name}";
-    }
-
     public string Value(object value)
     {
         if (value is null)
@@ -44,11 +39,6 @@ public class PowershellLanguageProvider : ILanguageProvider
         }
     }
 
-    public string Function(string name)
-    {
-        return name;
-    }
-
     public string Escape(string value)
     {
         return value.Replace("'", "''");
@@ -69,11 +59,6 @@ public class PowershellLanguageProvider : ILanguageProvider
             default:
                 throw new Exception($"Unknown test type: {sdkFunction.Kind}");
         }
-    }
-
-    public string ParameterList(params string[] parameters)
-    {
-        return string.Join(" ", parameters);
     }
 
     public string GetTemplateFileName()

--- a/BenchPress/Generators/LanguageProviders/PowershellLanguageProvider.cs
+++ b/BenchPress/Generators/LanguageProviders/PowershellLanguageProvider.cs
@@ -33,6 +33,17 @@ public class PowershellLanguageProvider : ILanguageProvider
         }
     }
 
+    public string AssertionDetails(TestType testType)
+    {
+        switch (testType)
+        {
+            case TestType.ResourceExists:
+                return "-BeSuccessful";
+            default:
+                throw new Exception($"Unknown test type: {testType}");
+        }
+    }
+
     public string Function(string name)
     {
         return name;

--- a/BenchPress/Generators/Program.cs
+++ b/BenchPress/Generators/Program.cs
@@ -55,10 +55,10 @@ rootCommand.SetHandler(
 
         foreach (var metadata in metadataList)
         {
-          foreach(var supportedTestType in metadata.ResourceType.GetSupportedTestTypes())
-          {
-            testList.Add(new TestDefinition(metadata, supportedTestType));
-          }
+            foreach (var supportedTestType in metadata.ResourceType.GetSupportedTestTypes())
+            {
+                testList.Add(new TestDefinition(metadata, supportedTestType));
+            }
         }
 
         AppDomain.CurrentDomain

--- a/BenchPress/Generators/Program.cs
+++ b/BenchPress/Generators/Program.cs
@@ -55,7 +55,10 @@ rootCommand.SetHandler(
 
         foreach (var metadata in metadataList)
         {
-            testList.Add(new TestDefinition(metadata, TestType.ResourceExists));
+          foreach(var supportedTestType in metadata.ResourceType.GetSupportedTestTypes())
+          {
+            testList.Add(new TestDefinition(metadata, supportedTestType));
+          }
         }
 
         AppDomain.CurrentDomain

--- a/BenchPress/Generators/ResourceTypes/ResourceType.cs
+++ b/BenchPress/Generators/ResourceTypes/ResourceType.cs
@@ -28,6 +28,12 @@ public abstract class ResourceType
     public abstract string FriendlyName { get; }
     public abstract string Prefix { get; }
     public abstract string FunctionPrefix { get; }
+
+    public virtual IEnumerable<TestType> GetSupportedTestTypes()
+    {
+        return new[] { TestType.ResourceExists };
+    }
+
     public abstract IEnumerable<KeyValuePair<string, object>> GetResourceParameters(TestMetadata m);
 
     protected static KeyValuePair<string, object> Param(string name, object value)

--- a/BenchPress/Generators/TestGenerator.cs
+++ b/BenchPress/Generators/TestGenerator.cs
@@ -65,10 +65,8 @@ public class TestGenerator
             Description = LanguageProvider.Escape(
                 $"It should contain a {definition.Metadata.ResourceType.FriendlyName} named {definition.Metadata.ResourceName}"
             ),
-            ResultVariable = LanguageProvider.Variable($"result"),
-            ActualValue = LanguageProvider.Variable($"result") + ".Success",
-            GetValueFunctionName = LanguageProvider.SDK(new SDKFunction(definition)),
-            ExpectedValue = LanguageProvider.Value(true)
+            FunctionName = LanguageProvider.SDK(new SDKFunction(definition)),
+            AssertionDetails = LanguageProvider.AssertionDetails(definition.Type)
         };
     }
 
@@ -77,10 +75,8 @@ public class TestGenerator
         public IEnumerable<KeyValuePair<string, string>> Parameters { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
-        public string ResultVariable { get; set; }
-        public string GetValueFunctionName { get; set; }
-        public string ActualValue { get; set; }
-        public string ExpectedValue { get; set; }
+        public string FunctionName { get; set; }
+        public string AssertionDetails { get; set; }
     }
 
     private IEnumerable<KeyValuePair<string, string>> GetParameters(TestDefinition definition)

--- a/BenchPress/Generators/templates/powershell/template.ps1
+++ b/BenchPress/Generators/templates/powershell/template.ps1
@@ -13,18 +13,15 @@ BeforeAll {
 {{#TestCases}}
 Describe '{{ Name }}' {
   it '{{ Description }}' {
-    #arrange
+    # arrange
     $params = @{
       {{ #Parameters }}
       {{ Key }} = {{{ Value }}}
       {{ /Parameters}}
     }
 
-    #act
-    {{ ResultVariable }} = {{GetValueFunctionName}} @params
-
-    #assert
-    {{ ActualValue }} | Should -Be {{{ ExpectedValue }}}
+    # act and assert
+    {{ FunctionName }} @params | Should {{{ AssertionDetails }}}
   }
 }
 


### PR DESCRIPTION
- Changes generated test from:
   ```
   $result = Confirm-AzBPResource @params
   $result.Success | Should -Be $true
  ```
  to:
   ```
   Confirm-AzBPResource @params | Should -BeSuccessful
   ```
- Cleans up the Language Provider Interface and removes methods no longer needed
- Adds a `GetSupportedTestTypes` method to base `ResourceType` class for the possibility of generating different types of tests (e.g. -InLocation) per derived class in the future

Closes #305.