### PR TITLE
Correctly format the resourceName in the GetExtraProperties method in Generator code 

### DIFF
--- a/BenchPress/Generators/AzureDeploymentImporter.cs
+++ b/BenchPress/Generators/AzureDeploymentImporter.cs
@@ -170,7 +170,7 @@ public class AzureDeploymentImporter
 
         var dependsOn = resource["dependsOn"]?[0]?.ToString().Trim().Split(",");
         var resourceIds = dependsOn?[0].Trim('\'').Split("/").Skip(1).ToArray();
-        var resourceNames = dependsOn?.Skip(1).ToArray();
+        var resourceNames = dependsOn?.Skip(1).Select(name => name.TrimEnd(')', ']')).ToArray();
         if (
             resourceIds != null
             && resourceNames != null
@@ -179,9 +179,12 @@ public class AzureDeploymentImporter
         {
             foreach (var resourceId in resourceIds)
             {
+                // When adding resource names to the dictionary, we need to add a closing
+                // parenthesis to the end of the resource name because the resource name is initially stripped
+                // all ending brackets and parenthesis
                 extraProperties.Add(
                     resourceId,
-                    resourceNames[Array.IndexOf(resourceIds, resourceId)]
+                    resourceNames[Array.IndexOf(resourceIds, resourceId)] + ")"
                 );
             }
         }

--- a/examples/ApiManagement/ApiManagement_Example.md
+++ b/examples/ApiManagement/ApiManagement_Example.md
@@ -20,7 +20,7 @@ cmdlets.
 
    ```Powershell
     New-AzResourceGroupDeployment -ResourceGroupName "<your-resource-group-name>"`
-    -TemplateFile ".\ApiManagement.bicep"
+    -TemplateFile ".\apiManagement.bicep"
    ```
 
 1. Update `ApiManagement.Tests.ps1` variables to point to your expected resources:


### PR DESCRIPTION
Title. Closes #311.

- Updated the code in `AzureDeploymentImporter` to remove all ending brackets when grabbing the resource names. It then adds a `)` on line 187 before adding to the dictionary. Open to another implementation of finding any resource names where the last two characters are open brackets.
- Updated `ApiManagement.bicep` to `apiManagement.bicep` to match our other examples (the file name is currently not propagating though)