### PR TITLE
adding workflow_displatch to module versioning workflow

### DIFF
--- a/.github/workflows/ci-module-versioning.yml
+++ b/.github/workflows/ci-module-versioning.yml
@@ -2,6 +2,7 @@
 name: ci-module-versioning
 
 on: # yamllint disable-line rule:truthy
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
Adding workflow dispatch to Module Version workflow in order to allow maintainers to trigger workflow directly.