### PR TITLE
adding build-modules job to psgallery cd workflow

### DIFF
--- a/.github/workflows/cd-psgallery.yml
+++ b/.github/workflows/cd-psgallery.yml
@@ -5,6 +5,24 @@ on: # yamllint disable-line rule:truthy
   workflow_dispatch:
 
 jobs:
+  build-modules:
+    name: Build the PS Gallery Modules
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v3
+      - name: Build Module Files
+        shell: pwsh
+        run: |
+          ./build.ps1 -InLine
+      - name: Archive Module artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: benchpress-gallery-module
+          path: |
+            ./bin/BenchPress.Azure.psd1
+            ./bin/BenchPress.Azure.psm1
+
   publish-to-gallery:
     name: Publish to the PowerShell Gallery
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a build-modules job to the workflow the releases to the PR gallery.