### PR TITLE
adding job dependencies in ps gallery cd workflow

### DIFF
--- a/.github/workflows/cd-psgallery.yml
+++ b/.github/workflows/cd-psgallery.yml
@@ -25,6 +25,7 @@ jobs:
 
   publish-to-gallery:
     name: Publish to the PowerShell Gallery
+    needs: build-modules
     runs-on: ubuntu-latest
     steps:
       - name: Download module artifacts


### PR DESCRIPTION
Adding a job dependency to ensure that publish only fires after build modules is complete.