### PR TITLE
#332 Update ci.yml to use the correct PS Gallery (local)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install AzBP Module from the repository
         shell: pwsh
         run: |
-          Install-Module BenchPress.Azure
+          Install-Module BenchPress.Azure -Repository LocalFeedPSRepo
       - name: Verify module exposes cmdlets (smoke test)
         shell: pwsh
         run: |


### PR DESCRIPTION
Fixing the `ci.yml` PS Gallery import to import from the local PS Gallery.

Closes #332 