### PR TITLE
Auth updates

### DIFF
--- a/Modules/BenchPress.Azure/BenchPress.Azure.psd1
+++ b/Modules/BenchPress.Azure/BenchPress.Azure.psd1
@@ -3,7 +3,7 @@
 # Generated on: 12/1/2022
 @{
   RootModule           = "BenchPress.Azure.psm1"
-  ModuleVersion        = "0.2.2"
+  ModuleVersion        = "0.2.3"
   GUID                 = "3db0c6b2-7453-4972-a9de-402be1277ac9"
   Author               = "CSEDevOps"
   CompanyName          = "Microsoft"

--- a/Modules/BenchPress.Azure/Private/Connect-Account.ps1
+++ b/Modules/BenchPress.Azure/Private/Connect-Account.ps1
@@ -42,7 +42,7 @@ function Connect-Account {
   param ( )
   Begin { }
   Process {
-    $useManagedIdentity = Get-EnvironmentVariable AZ_USE_MANAGED_IDENTITY -DontThrowIfMissing
+    $useManagedIdentity = Get-BooleanEnvironmentVariable AZ_USE_MANAGED_IDENTITY
     $subscriptionId = Get-EnvironmentVariable AZ_SUBSCRIPTION_ID -DontThrowIfMissing
     $applicationId = Get-EnvironmentVariable AZ_APPLICATION_ID -DontThrowIfMissing
     $tenantId = Get-EnvironmentVariable AZ_TENANT_ID -DontThrowIfMissing

--- a/Modules/BenchPress.Azure/Private/Connect-Account.ps1
+++ b/Modules/BenchPress.Azure/Private/Connect-Account.ps1
@@ -58,7 +58,7 @@ function Connect-Account {
       # Login Using Managed Identity
       if ($useManagedIdentity) {
         $connection = Connect-AzAccount -Identity
-        if ($subscriptionId -ne $null) {
+        if ($null -ne $subscriptionId) {
           $subscriptionName = (Get-AzSubscription -SubscriptionId  $subscriptionId).Name
           Set-AzContext -Subscription $subscriptionName
         }
@@ -72,7 +72,7 @@ function Connect-Account {
           $clientSecret = Get-EnvironmentVariable AZ_ENCRYPTED_PASSWORD | ConvertTo-SecureString
           $clientSecret = New-Object System.Management.Automation.PSCredential -ArgumentList $applicationId, $clientSecret
 
-          if ($currentConnection -ne $null){
+          if ($null -ne $currentConnection){
             Write-Warning "Logging out of current Az.Powershell context and connecting to Subscription: $subscriptionId"
           }
 
@@ -105,7 +105,7 @@ function IsCurrentAccountLoggedIn($currentConnection) {
     return $False
   }
 
-  if ($subscriptionId -eq $null -or $applicationId -eq $null -or $tenantId -eq $null) {
+  if ($null -eq $subscriptionId -or $null -eq $applicationId -or $null -eq $tenantId) {
     return $True
   }
 

--- a/Modules/BenchPress.Azure/Private/Connect-Account.ps1
+++ b/Modules/BenchPress.Azure/Private/Connect-Account.ps1
@@ -58,8 +58,10 @@ function Connect-Account {
       # Login Using Managed Identity
       if ($useManagedIdentity) {
         $connection = Connect-AzAccount -Identity
-        $subscriptionName = (Get-AzSubscription -SubscriptionId  $subscriptionId).Name
-        Set-AzContext -Subscription $subscriptionName
+        if ($subscriptionId -ne $null) {
+          $subscriptionName = (Get-AzSubscription -SubscriptionId  $subscriptionId).Name
+          Set-AzContext -Subscription $subscriptionName
+        }
 
         $results.Success = $true
         $results.AuthenticationData = [AuthenticationData]::new($connection.Context.Subscription.Id)

--- a/Modules/BenchPress.Azure/Private/Connect-Account.ps1
+++ b/Modules/BenchPress.Azure/Private/Connect-Account.ps1
@@ -43,65 +43,73 @@ function Connect-Account {
   Begin { }
   Process {
     $useManagedIdentity = Get-EnvironmentVariable AZ_USE_MANAGED_IDENTITY -DontThrowIfMissing
-    $subscriptionId = Get-EnvironmentVariable AZ_SUBSCRIPTION_ID
+    $subscriptionId = Get-EnvironmentVariable AZ_SUBSCRIPTION_ID -DontThrowIfMissing
+    $applicationId = Get-EnvironmentVariable AZ_APPLICATION_ID -DontThrowIfMissing
+    $tenantId = Get-EnvironmentVariable AZ_TENANT_ID -DontThrowIfMissing
+
     $currentConnection = Get-AzContext
     $results = [AuthenticationResult]::new()
 
-    # Login Using Managed Identity
-    if ($useManagedIdentity) {
-      $connection = Connect-AzAccount -Identity
-      $subscriptionName = (Get-AzSubscription -SubscriptionId  $subscriptionId).Name
-      Set-AzContext -Subscription $subscriptionName
-
+    if (IsCurrentAccountLoggedIn($currentConnection)) {
       $results.Success = $true
-      $results.AuthenticationData = [AuthenticationData]::new($connection.Context.Subscription.Id)
+      $results.AuthenticationData = [AuthenticationData]::new(($currentConnection).Subscription.Id)
     }
     else {
-      # If the current context matches the subscription, tenant, and service principal, then we're already properly logged in.
-      $applicationId = Get-EnvironmentVariable AZ_APPLICATION_ID
-      $tenantId = Get-EnvironmentVariable AZ_TENANT_ID
+      # Login Using Managed Identity
+      if ($useManagedIdentity) {
+        $connection = Connect-AzAccount -Identity
+        $subscriptionName = (Get-AzSubscription -SubscriptionId  $subscriptionId).Name
+        Set-AzContext -Subscription $subscriptionName
 
-      if (IsCurrentAccountLoggedIn($currentConnection)) {
         $results.Success = $true
-        $results.AuthenticationData = [AuthenticationData]::new(($currentConnection).Subscription.Id)
+        $results.AuthenticationData = [AuthenticationData]::new($connection.Context.Subscription.Id)
       }
       else {
-        # The current context is not correct
-        # Create the credentials and login to the correct account
+          # The current context is not correct
+          # Create the credentials and login to the correct account
+          $clientSecret = Get-EnvironmentVariable AZ_ENCRYPTED_PASSWORD | ConvertTo-SecureString
+          $clientSecret = New-Object System.Management.Automation.PSCredential -ArgumentList $applicationId, $clientSecret
 
-        $clientSecret = Get-EnvironmentVariable AZ_ENCRYPTED_PASSWORD | ConvertTo-SecureString
-        $clientSecret = New-Object System.Management.Automation.PSCredential -ArgumentList $applicationId, $clientSecret
-
-        try {
-          $connectionParams = @{
-            Credential   = $clientSecret
-            TenantId     = $tenantId
-            Subscription = $subscriptionId
+          if ($currentConnection -ne $null){
+            Write-Warning "Logging out of current Az.Powershell context and connecting to Subscription: $subscriptionId"
           }
-          $connection = Connect-AzAccount -ServicePrincipal @connectionParams
 
-          $results.Success = $true
-          $results.AuthenticationData = [AuthenticationData]::new($connection.Context.Subscription.Id)
-        }
-        catch {
-          $thrownError = $_
-          $results.Success = $false
-          Write-Error $thrownError
-        }
+          try {
+            $connectionParams = @{
+              Credential   = $clientSecret
+              TenantId     = $tenantId
+              Subscription = $subscriptionId
+            }
+            $connection = Connect-AzAccount -ServicePrincipal @connectionParams
+
+            $results.Success = $true
+            $results.AuthenticationData = [AuthenticationData]::new($connection.Context.Subscription.Id)
+          }
+          catch {
+            $thrownError = $_
+            $results.Success = $false
+            Write-Error $thrownError
+          }
       }
-
     }
+
     $results
   }
   End { }
 }
 
 function IsCurrentAccountLoggedIn($currentConnection) {
-  if ($null -ne $currentConnection `
-      -and ($currentConnection).Account.Type -eq 'ServicePrincipal' `
-      -and ($currentConnection).Account.Id -eq $applicationId `
-      -and ($currentConnection).Tenant.Id -eq $tenantId `
-      -and ($currentConnection).Subscription.Id -eq $subscriptionId) {
+  if ($null -eq $currentConnection) {
+    return $False
+  }
+
+  if ($subscriptionId -eq $null -or $applicationId -eq $null -or $tenantId -eq $null) {
+    return $True
+  }
+
+  if ($currentConnection.Account.Id -eq $applicationId `
+      -and $currentConnection.Tenant.Id -eq $tenantId `
+      -and $currentConnection.Subscription.Id -eq $subscriptionId) {
     return $True
   }
 

--- a/Modules/BenchPress.Azure/Private/Get-EnvironmentVariable.ps1
+++ b/Modules/BenchPress.Azure/Private/Get-EnvironmentVariable.ps1
@@ -70,3 +70,26 @@ function Get-RequiredEnvironmentVariable {
     $value
   }
 }
+
+
+function Get-BooleanEnvironmentVariable {
+  [OutputType([System.Boolean])]
+  param (
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$VariableName
+  )
+  Begin {
+    $result = $False
+  }
+  Process {
+    $value = Get-EnvironmentVariable $VariableName -DontThrowIfMissing
+    try {
+      $result = [System.Convert]::ToBoolean($value)
+    } catch [FormatException] {
+      $result = $False
+    }
+  }
+  End {
+    $result
+  }
+}

--- a/Modules/BenchPress.Azure/Tests/Private/Connect-Account.Tests.ps1
+++ b/Modules/BenchPress.Azure/Tests/Private/Connect-Account.Tests.ps1
@@ -71,7 +71,9 @@ Describe "Connect-Account" {
     }
 
     It "Invokes Connect-AzAccount with -ServicePrincipal when the context is empty and environment variables exist" {
-      Mock Get-AzContext { return $null} -Verifiable
+      Mock Get-BooleanEnvironmentVariable{ return $False } -ParameterFilter { $VariableName -eq "AZ_USE_MANAGED_IDENTITY" }
+      Mock Get-AzContext { return $null } -Verifiable
+      Mock Set-AzContext {}
 
       Connect-Account
 

--- a/Modules/BenchPress.Azure/Tests/Public/Get-ResourceByType.Tests.ps1
+++ b/Modules/BenchPress.Azure/Tests/Public/Get-ResourceByType.Tests.ps1
@@ -69,8 +69,15 @@ Describe "Get-ResourceByType" {
 
       Mock $functionName {}
 
-      Get-ResourceByType @params
-      | Should -Invoke -CommandName $Expected -Times 1 -ParameterFilter {$filterString}
+      if ($filterString -eq "") {
+        Get-ResourceByType @params
+        | Should -Invoke -CommandName $Expected -Times 1
+      }
+      else{
+        Get-ResourceByType @params
+        | Should -Invoke -CommandName $Expected -Times 1 -ParameterFilter {$filterString}
+      }
+
     }
   }
 }

--- a/assets/demos/main.bicep
+++ b/assets/demos/main.bicep
@@ -14,7 +14,7 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
   }
 }
 
-resource emailActionGroup 'Microsoft.Insights/actionGroups@2022-06-01' = {
+resource emailActionGroup 'Microsoft.Insights/actionGroups@2023-01-01' = {
   name: join( ['benchpress', 'email', 'action', 'group', suffix ], '-')
   location: 'global'
   properties: {
@@ -33,7 +33,7 @@ resource emailActionGroup 'Microsoft.Insights/actionGroups@2022-06-01' = {
   }
 }
 
-resource hostingPlan 'Microsoft.Web/serverfarms@2022-03-01' = {
+resource hostingPlan 'Microsoft.Web/serverfarms@2024-04-01' = {
   name: join( ['benchpress', 'hosting', 'plan', suffix ], '-')
   location: location
   sku: {
@@ -45,7 +45,7 @@ resource hostingPlan 'Microsoft.Web/serverfarms@2022-03-01' = {
   }
 }
 
-resource webApp 'Microsoft.Web/sites@2022-03-01' = {
+resource webApp 'Microsoft.Web/sites@2024-04-01' = {
   name: join( ['benchpress', 'web', suffix ], '-')
   location: location
   identity: {

--- a/examples/AksCluster/aksCluster.bicep
+++ b/examples/AksCluster/aksCluster.bicep
@@ -1,7 +1,7 @@
 param aksName string = 'aks${take(uniqueString(resourceGroup().id), 5)}'
 param location string = resourceGroup().location
 
-resource aksCluster 'Microsoft.ContainerService/managedClusters@2022-09-01' = {
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
   name: aksName
   location: location
   identity: {
@@ -24,7 +24,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2022-09-01' = {
 
 param agentPoolName string = 'ap${take(uniqueString(resourceGroup().id), 5)}'
 
-resource agentPool 'Microsoft.ContainerService/managedClusters/agentPools@2022-09-01' = {
+resource agentPool 'Microsoft.ContainerService/managedClusters/agentPools@2024-09-01' = {
   name: agentPoolName
   parent: aksCluster
   properties: {

--- a/examples/ApiManagement/ApiManagement.bicep
+++ b/examples/ApiManagement/ApiManagement.bicep
@@ -1,7 +1,7 @@
 param serviceName string = 'apim${take(uniqueString(resourceGroup().id), 5)}'
 param location string = resourceGroup().location
 
-resource apiManagementService 'Microsoft.ApiManagement/service@2022-08-01' = {
+resource apiManagementService 'Microsoft.ApiManagement/service@2024-05-01' = {
   name: serviceName
   location: location
   sku: {
@@ -16,7 +16,7 @@ resource apiManagementService 'Microsoft.ApiManagement/service@2022-08-01' = {
 
 param apiName string = 'api${take(uniqueString(resourceGroup().id), 5)}'
 
-resource api 'Microsoft.ApiManagement/service/apis@2022-08-01' = {
+resource api 'Microsoft.ApiManagement/service/apis@2024-05-01' = {
   name: apiName
   parent: apiManagementService
   properties: {
@@ -28,7 +28,7 @@ resource api 'Microsoft.ApiManagement/service/apis@2022-08-01' = {
 
 param workspaceName string = 'logworkspace${take(uniqueString(resourceGroup().id), 5)}'
 
-resource workspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+resource workspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   name: workspaceName
   location: location
   properties: {
@@ -52,7 +52,7 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
 
 param loggerName string = 'log${take(uniqueString(resourceGroup().id), 5)}'
 
-resource logger 'Microsoft.ApiManagement/service/loggers@2022-08-01' = {
+resource logger 'Microsoft.ApiManagement/service/loggers@2024-05-01' = {
   name: loggerName
   parent: apiManagementService
   properties: {
@@ -65,7 +65,7 @@ resource logger 'Microsoft.ApiManagement/service/loggers@2022-08-01' = {
 
 param diagnosticName string = 'applicationinsights'
 
-resource diagnostic 'Microsoft.ApiManagement/service/diagnostics@2022-08-01' = {
+resource diagnostic 'Microsoft.ApiManagement/service/diagnostics@2024-05-01' = {
   name: diagnosticName
   parent: apiManagementService
   properties: {
@@ -75,7 +75,7 @@ resource diagnostic 'Microsoft.ApiManagement/service/diagnostics@2022-08-01' = {
 
 param policyName string = 'policy'
 
-resource apiPolicy 'Microsoft.ApiManagement/service/apis/policies@2022-08-01' = {
+resource apiPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-05-01' = {
   name: policyName
   parent: api
   properties: {

--- a/examples/AppInsights/appInsights.bicep
+++ b/examples/AppInsights/appInsights.bicep
@@ -2,7 +2,7 @@ param appInsightsName string = 'appinsights${take(uniqueString(resourceGroup().i
 param workspaceName string = 'logworkspace${take(uniqueString(resourceGroup().id), 5)}'
 param location string = resourceGroup().location
 
-resource workspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+resource workspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   name: workspaceName
   location: location
   properties: {
@@ -22,7 +22,7 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
   }
 }
 
-resource appInsightsDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+resource appInsightsDiagnostics 'microsoft.insights/diagnosticSettings@2016-09-01' = {
   scope: applicationInsights
   name: 'default'
   properties: {

--- a/examples/AppInsights/appInsights.bicep
+++ b/examples/AppInsights/appInsights.bicep
@@ -21,8 +21,8 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
     WorkspaceResourceId: workspace.id
   }
 }
-
-resource appInsightsDiagnostics 'microsoft.insights/diagnosticSettings@2016-09-01' = {
+#disable-next-line use-recent-api-versions //Disabling since this is the latest preview version available.
+resource appInsightsDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
   scope: applicationInsights
   name: 'default'
   properties: {

--- a/examples/AppServicePlan/appServicePlan.bicep
+++ b/examples/AppServicePlan/appServicePlan.bicep
@@ -1,7 +1,7 @@
 param location string = resourceGroup().location
 param name string = 'asp${take(uniqueString(resourceGroup().id), 5)}'
 
-resource appServicePlan 'Microsoft.Web/serverfarms@2022-03-01' = {
+resource appServicePlan 'Microsoft.Web/serverfarms@2024-04-01' = {
   name: name
   location: location
   sku: {

--- a/examples/ContainerApp/containerApp.bicep
+++ b/examples/ContainerApp/containerApp.bicep
@@ -3,7 +3,7 @@ param location string = resourceGroup().location
 param targetPort int = 80
 param containerImage string = 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
 
-resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   name: 'loganalytics${containerAppName}'
   location: location
   properties: {
@@ -13,7 +13,7 @@ resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
   }
 }
 
-resource containerAppEnv 'Microsoft.App/managedEnvironments@2022-10-01' = {
+resource containerAppEnv 'Microsoft.App/managedEnvironments@2024-03-01' = {
   name: 'env${containerAppName}'
   location: location
   sku: {
@@ -30,7 +30,7 @@ resource containerAppEnv 'Microsoft.App/managedEnvironments@2022-10-01' = {
   }
 }
 
-resource containerApp 'Microsoft.App/containerApps@2022-10-01' = {
+resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
   name: containerAppName
   location: location
   properties: {

--- a/examples/CosmosDB/cosmosDB.bicep
+++ b/examples/CosmosDB/cosmosDB.bicep
@@ -53,7 +53,7 @@ var locations = [
 var roleDefinitionId = guid('sql-role-definition-', svcPrincipalObjectId, sql_account.id)
 var roleAssignmentId = guid(roleDefinitionId, svcPrincipalObjectId, sql_account.id)
 
-resource gremlin_account 'Microsoft.DocumentDB/databaseAccounts@2022-05-15' = {
+resource gremlin_account 'Microsoft.DocumentDB/databaseAccounts@2024-11-15' = {
   name: toLower(gremlinAccountName)
   location: location
   kind: 'GlobalDocumentDB'
@@ -72,7 +72,7 @@ resource gremlin_account 'Microsoft.DocumentDB/databaseAccounts@2022-05-15' = {
   }
 }
 
-resource gremlin_database 'Microsoft.DocumentDB/databaseAccounts/gremlinDatabases@2022-05-15' = {
+resource gremlin_database 'Microsoft.DocumentDB/databaseAccounts/gremlinDatabases@2024-11-15' = {
   name: '${gremlin_account.name}/${gremlinDatabaseName}'
   properties: {
     resource: {
@@ -81,7 +81,7 @@ resource gremlin_database 'Microsoft.DocumentDB/databaseAccounts/gremlinDatabase
   }
 }
 
-resource mongo_account 'Microsoft.DocumentDB/databaseAccounts@2022-05-15' = {
+resource mongo_account 'Microsoft.DocumentDB/databaseAccounts@2024-11-15' = {
   name: toLower(mongoAccountName)
   location: location
   kind: 'MongoDB'
@@ -103,7 +103,7 @@ resource mongo_account 'Microsoft.DocumentDB/databaseAccounts@2022-05-15' = {
   }
 }
 
-resource mongo_database 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases@2022-05-15' = {
+resource mongo_database 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases@2024-11-15' = {
   parent: mongo_account
   name: mongoDBDatabaseName
   properties: {
@@ -118,7 +118,7 @@ resource mongo_database 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases@
   }
 }
 
-resource sql_account 'Microsoft.DocumentDB/databaseAccounts@2022-05-15' = {
+resource sql_account 'Microsoft.DocumentDB/databaseAccounts@2024-11-15' = {
   name: toLower(sqlAccountName)
   location: location
   kind: 'GlobalDocumentDB'
@@ -132,7 +132,7 @@ resource sql_account 'Microsoft.DocumentDB/databaseAccounts@2022-05-15' = {
   }
 }
 
-resource sql_database 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2022-05-15' = {
+resource sql_database 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-11-15' = {
   name: '${sql_account.name}/${sqlDatabaseName}'
   properties: {
     resource: {
@@ -141,7 +141,7 @@ resource sql_database 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2022-0
   }
 }
 
-resource sqlRoleDefinition 'Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions@2022-11-15' = {
+resource sqlRoleDefinition 'Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions@2024-11-15' = {
   name: '${sql_account.name}/${roleDefinitionId}'
   properties: {
     roleName: roleDefinitionName
@@ -157,7 +157,7 @@ resource sqlRoleDefinition 'Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinit
   }
 }
 
-resource sqlRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2022-11-15' = {
+resource sqlRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-11-15' = {
   name: '${sql_account.name}/${roleAssignmentId}'
   properties: {
     roleDefinitionId: sqlRoleDefinition.id

--- a/examples/Dashboard/dashboard.bicep
+++ b/examples/Dashboard/dashboard.bicep
@@ -2,7 +2,7 @@ param dashboardName string = 'dash${take(uniqueString(resourceGroup().id), 5)}'
 param dashboardDisplayName string = 'Sample Dashboard'
 param location string = resourceGroup().location
 
-resource dashboard 'Microsoft.Portal/dashboards@2020-09-01-preview' = {
+resource dashboard 'Microsoft.Portal/dashboards@2022-12-01-preview' = {
   name: dashboardName
   location: location
   tags: {

--- a/examples/DataFactory/dataFactory.bicep
+++ b/examples/DataFactory/dataFactory.bicep
@@ -8,7 +8,7 @@ var dataFactoryDataSetInName = 'BenchpressTestDatasetIn'
 var dataFactoryDataSetOutName = 'BenchpressTestDatasetOut'
 var pipelineName = 'BenchpressSampleCopyPipeline'
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   name: storageAccountName
   location: location
   sku: {
@@ -17,12 +17,12 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   kind: 'StorageV2'
 }
 
-resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' = {
   parent: storageAccount
   name: 'default'
 }
 
-resource blobContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-01-01' = {
+resource blobContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
   parent: blobService
   name: blobContainerName
 }

--- a/examples/EventHub/eventHub.bicep
+++ b/examples/EventHub/eventHub.bicep
@@ -5,7 +5,7 @@ param location string = resourceGroup().location
 
 var eventHubSku = 'Standard'
 
-resource eventHubNamespace 'Microsoft.EventHub/namespaces@2021-11-01' = {
+resource eventHubNamespace 'Microsoft.EventHub/namespaces@2024-01-01' = {
   name: eventHubNamespaceName
   location: location
   sku: {
@@ -19,7 +19,7 @@ resource eventHubNamespace 'Microsoft.EventHub/namespaces@2021-11-01' = {
   }
 }
 
-resource eventHub 'Microsoft.EventHub/namespaces/eventhubs@2021-11-01' = {
+resource eventHub 'Microsoft.EventHub/namespaces/eventhubs@2024-01-01' = {
   parent: eventHubNamespace
   name: name
   properties: {
@@ -28,7 +28,7 @@ resource eventHub 'Microsoft.EventHub/namespaces/eventhubs@2021-11-01' = {
   }
 }
 
-resource eventHubConsumerGroup 'Microsoft.EventHub/namespaces/eventhubs/consumergroups@2021-11-01' = {
+resource eventHubConsumerGroup 'Microsoft.EventHub/namespaces/eventhubs/consumergroups@2024-01-01' = {
   name: consumerGroupName
   parent: eventHub
 }

--- a/examples/KeyVault/keyVault.bicep
+++ b/examples/KeyVault/keyVault.bicep
@@ -2,7 +2,7 @@ param name string = 'kv${take(uniqueString(resourceGroup().id), 5)}'
 param location string = resourceGroup().location
 param svcPrincipalObjectId string
 
-resource vault 'Microsoft.KeyVault/vaults@2022-07-01' = {
+resource vault 'Microsoft.KeyVault/vaults@2023-07-01' = {
   name: name
   location: location
   properties: {
@@ -34,7 +34,7 @@ resource vault 'Microsoft.KeyVault/vaults@2022-07-01' = {
   }
 }
 
-resource key 'Microsoft.KeyVault/vaults/keys@2022-07-01' = {
+resource key 'Microsoft.KeyVault/vaults/keys@2023-07-01' = {
   parent: vault
   name: 'samplekey'
   properties: {
@@ -45,7 +45,7 @@ resource key 'Microsoft.KeyVault/vaults/keys@2022-07-01' = {
   }
 }
 
-resource secret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+resource secret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   parent: vault
   name: 'samplesecret'
   properties: {

--- a/examples/OperationalInsightsWorkspace/operationalInsightsWorkspace.bicep
+++ b/examples/OperationalInsightsWorkspace/operationalInsightsWorkspace.bicep
@@ -3,7 +3,7 @@ targetScope = 'resourceGroup'
 param name string = 'oiw${take(uniqueString(subscription().id), 5)}'
 param location string = resourceGroup().location
 
-resource symbolicname 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+resource symbolicname 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   name: name
   location: location
 }

--- a/examples/PostgreSql/postgresql.bicep
+++ b/examples/PostgreSql/postgresql.bicep
@@ -3,7 +3,7 @@ param location string = resourceGroup().location
 param adminPassword string
 param name string = 'psql${take(uniqueString(subscription().id), 5)}'
 
-resource symbolicname 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' = {
+resource symbolicname 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
   name: name
   location: location
   sku: {

--- a/examples/ResourceGroup/ResourceGroup.Tests.ps1
+++ b/examples/ResourceGroup/ResourceGroup.Tests.ps1
@@ -1,4 +1,5 @@
 ﻿BeforeAll {
+  Import-Module BenchPress.Azure
 
   $Script:rgName = 'rg-test'
   $Script:noRgName = 'notestrg'
@@ -47,4 +48,6 @@ Describe 'Verify Resource Group Exists' {
   }
 }
 
-
+AfterAll {
+  Get-Module BenchPress.Azure | Remove-Module
+}

--- a/examples/ResourceGroup/ResourceGroup.Tests.ps1
+++ b/examples/ResourceGroup/ResourceGroup.Tests.ps1
@@ -1,5 +1,4 @@
 ﻿BeforeAll {
-  Import-Module BenchPress.Azure
 
   $Script:rgName = 'rg-test'
   $Script:noRgName = 'notestrg'
@@ -48,6 +47,4 @@ Describe 'Verify Resource Group Exists' {
   }
 }
 
-AfterAll {
-  Get-Module BenchPress.Azure | Remove-Module
-}
+

--- a/examples/ResourceGroup/resourceGroup.bicep
+++ b/examples/ResourceGroup/resourceGroup.bicep
@@ -4,7 +4,7 @@ param name string = 'rg${take(uniqueString(subscription().id), 5)}'
 param location string = deployment().location
 
 // https://docs.microsoft.com/en-us/azure/templates/microsoft.resources/resourcegroups?tabs=bicep
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-07-01' = {
   name: name
   location: location
 }

--- a/examples/SQL/sql.bicep
+++ b/examples/SQL/sql.bicep
@@ -4,7 +4,7 @@ param databaseName string = 'sqldb${take(uniqueString(resourceGroup().id), 5)}'
 @secure()
 param adminPassword string
 
-resource sqlServer 'Microsoft.Sql/servers@2022-05-01-preview' = {
+resource sqlServer 'Microsoft.Sql/servers@2024-05-01-preview' = {
   name: serverName
   location: location
   properties: {
@@ -13,7 +13,7 @@ resource sqlServer 'Microsoft.Sql/servers@2022-05-01-preview' = {
   }
 }
 
-resource sqlDB 'Microsoft.Sql/servers/databases@2022-05-01-preview' = {
+resource sqlDB 'Microsoft.Sql/servers/databases@2024-05-01-preview' = {
   parent: sqlServer
   name: databaseName
   location: location

--- a/examples/SearchService/SearchService.bicep
+++ b/examples/SearchService/SearchService.bicep
@@ -1,7 +1,7 @@
 param location string = resourceGroup().location
 param name string = 'search${take(uniqueString(resourceGroup().id), 5)}'
 
-resource search 'Microsoft.Search/searchServices@2022-09-01' = {
+resource search 'Microsoft.Search/searchServices@2023-11-01' = {
   name: name
   location: location
   properties: {

--- a/examples/Storage/storage.bicep
+++ b/examples/Storage/storage.bicep
@@ -1,7 +1,7 @@
 param location string = resourceGroup().location
 param name string = 'str${take(uniqueString(resourceGroup().id), 6)}'
 
-resource storage 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   name: name
   location: location
   kind: 'StorageV2'
@@ -13,12 +13,12 @@ resource storage 'Microsoft.Storage/storageAccounts@2022-09-01' = {
   }
 }
 
-resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2022-09-01' = {
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' = {
   parent: storage
   name: 'default'
 }
 
-resource container 'Microsoft.Storage/storageAccounts/blobServices/containers@2022-09-01' = {
+resource container 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
   parent: blobService
   name: 'azbenchpresscontainer'
 }

--- a/examples/Synapse/synapse.bicep
+++ b/examples/Synapse/synapse.bicep
@@ -6,7 +6,7 @@ param synapse_sqlpool_admin_username string = 'sqlAdmin'
 @secure()
 param synapse_sqlpool_admin_password string
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   name: adlsName
   location: location
   sku: {
@@ -14,13 +14,13 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
   }
   kind: 'StorageV2'
 
-  resource synapseStorageFileSystem 'blobServices@2022-09-01' = {
+  resource synapseStorageFileSystem 'blobServices@2023-05-01' = {
     name: 'default'
     properties: {
       isVersioningEnabled: false
     }
 
-    resource synapseStorageFileSystem2 'containers@2022-09-01' = {
+    resource synapseStorageFileSystem2 'containers@2023-05-01' = {
       name: adlsFsName
       properties: {
         publicAccess: 'None'

--- a/examples/WebApp/webApp.bicep
+++ b/examples/WebApp/webApp.bicep
@@ -4,7 +4,7 @@ param appserviceplanName string = 'asp${take(uniqueString(resourceGroup().id), 5
 param webappName string = 'webapp${take(uniqueString(resourceGroup().id), 5)}'
 param staticwebappName string = 'staticwebapp${take(uniqueString(resourceGroup().id), 5)}'
 
-resource appserviceplan 'Microsoft.Web/serverfarms@2022-03-01' = {
+resource appserviceplan 'Microsoft.Web/serverfarms@2022-09-01' = {
   name: appserviceplanName
   location: location
   tags: {
@@ -25,7 +25,7 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
   }
 }
 
-resource website 'Microsoft.Web/sites@2022-03-01' = {
+resource website 'Microsoft.Web/sites@2024-04-01' = {
   name: webappName
   location: location
   tags: {
@@ -45,7 +45,7 @@ resource website 'Microsoft.Web/sites@2022-03-01' = {
   }
 }
 
-resource staticwebsite 'Microsoft.Web/staticSites@2022-03-01' = {
+resource staticwebsite 'Microsoft.Web/staticSites@2024-04-01' = {
   name: staticwebappName
   location: location
   tags: {


### PR DESCRIPTION
This change affects the auth mechanism and specifically introduces the following:

- If Az.Powershell is connected, skip all auth and use existing connection. This also removes the need to set environment variables if the connection is existing.
- If environment variables are set, check that subscription id, tenant ip and application id match the current context, if not, throw an error.
- Remove the need to specify a subscription id for managed identities. It can still be passed it as optional if there is a specific subscription that needs to be used.